### PR TITLE
Remove duplicate entry

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -10,12 +10,6 @@
   <email>Qianqian.Bu@microsoft.com</email>
   <active>yes</active>
  </lead>
- <developer>
-  <name>Qianqian Bu</name>
-  <user>bqq</user>
-  <email>Qianqian.Bu@microsoft.com</email>
-  <active>yes</active>
- </developer>
  <date>2019-10-31</date>
  <time>12:00:13</time>
  <version>


### PR DESCRIPTION
If you have both, any time you upload a package, the PECL web site will use the last one for your user, and hence remove your lead status in favour of developer. (And then I have to fix it again ;-) ).