### PR TITLE
adjust design. 

### DIFF
--- a/Notes.txt
+++ b/Notes.txt
@@ -9,7 +9,7 @@ connection, and use the new one afterward.
 +---------------------------+
 OPTION DESCRIPTION
 ------------------ ----------------------------------------------------------
-mysqlnd_azure.enabled This option is to control enable or disable mysqlnd_rd. 
+mysqlnd_azure.enableRedirect This option is to control enable or disable redirection feature of mysqlnd_azure.
 If this is set to 0, it will not use redirection.
 (Default: 0)
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Extension name: **mysqlnd_azure**
 Required PHP min version: PHP7.2.15+ and PHP7.3.2+.
 
 Valid version:
-- 1.0.0  Change: initial version. Limitation: cannot install with pecl on linux; cannot work with 7.2.23+ and 7.3.10+
+- 1.0.0  Change: initial version. Limitation: cannot install with pecl on linux, the package on PECL website is invalid, only possible to install with manual compilation on Linux. Cannot work with 7.2.23+ and 7.3.10+
 - 1.0.1  Change: with pecl install command line support on linux. Limitation: cannot work with 7.2.23+ and 7.3.10+
 - 1.0.2  Change: fix compatibility problem with  7.2.23+ and 7.3.10+
 - 1.1.0Beta  Change: In preious versions, if connection does not use SSL, or server does not support redirection, or redirected connection fails to connect for some reason, it will fallback to the first proxy connection. Since 1.0.3, the logic changes as follows: 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # PHP mysqlnd redirection extension mysqlnd_azure
 The source code here is a PHP extension implemented using mysqlnd plugin API (https://www.php.net/manual/en/mysqlnd.plugin.php), which provides redirection feature support.  The extension is also available on PECL website at  https://pecl.php.net/package/mysqlnd_azure.
-```diff
-!**Important notice:** There is a limitation that for Azure MySQL, redirection is only possible when the connection is configured with SSL.
-```
+
+**Important notice: There is a limitation that for Azure MySQL, redirection is only possible when the connection is configured with SSL.**
+
 In 1.0.x versions, if connection does not use SSL, or server does not support redirection, or redirected connection fails to connect for any non-fatal reason while the proxy connection is still a valid one, it will fallback to the first proxy connection. 
 
 Since 1.1.0beta1, the logic changes as follows:

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Since 1.1.0Beta, the logic changes as follows:
 
 ```
 Ask from you:
-In version 1.1.0Beta, we add many restrictions when the feature is turned on, but fallback is then not possible any +more. We also want to hear from you that given the following two options, what will you prefer:
- 1. Add another option "preferred" with fallback support (i.e. go without redirection if SSL is not used or server doesnot support +redirection or do not need redirection).
- 2. Remove the restrictions when redrection is turned on, still go without redirection if SSL is not used or server doesnot support redirection or do not need redirection. 
+In version 1.1.0Beta, we add many restrictions when the feature is turned on, but fallback is then not possible anymore. We also want to hear from you that given the following two options, what will you prefer:
+ 1. Add another option "preferred" with fallback support (i.e. go without redirection if SSL is not used or server does not support redirection or do not need redirection).
+ 2. Remove the restrictions when redrection is turned on, still go without redirection if SSL is not used or server does not support redirection or do not need redirection.
 
 You may vote for your preference by giving comment on issue page on github or send email to the people of maintenance which you can find in the file named with package.xml.
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # PHP mysqlnd redirection extension mysqlnd_azure
 The source code here is a PHP extension implemented using mysqlnd plugin API (https://www.php.net/manual/en/mysqlnd.plugin.php), which provides redirection feature support.  The extension is also available on PECL website at  https://pecl.php.net/package/mysqlnd_azure.
 
+Please notice that there is a limitation that redirection is only possible when the connection is configured with SSL.
+In 1.0.x versions, if connection does not use SSL, or server does not support redirection, or redirected connection fails to connect for some reason, 
+it will fallback to the first proxy connection. Since 1.1.0Beta, the logic changes as follows:
+ 	1. If redirection is on, ssl is off, no connection will be made, it will return error "mysqlnd_azure.enableRedirect is on, but SSL option is not set. Redirection is only possible with SSL."
+	2. If redirection is on, but on server side redirection is not available (e.g. a community verion mysql installed locally), it will abort the first connection and return error "No redirection information available, redirection is not possible. Abort the connection."
+	3. If redirected connection failed for any reason, it will also abort the first proxy connection, and return the error of the redirected connection.
+Ask from you: in version 1.1.0Beta, we add many restrictions when the feature is turned on, but fallback is then not possible any more. We also want to hear from you that given the 
+              following two options, what will you prefer:
+              1. Add another option "preferred" with fallback support (i.e. go without redirection if SSL is not used or server doesnot support redirection or do not need redirection).
+              2. Remove the restrictions when redrection is turned on, still go without redirection if SSL is not used or server doesnot support redirection or do not need redirection. 
+              
+              You may vote for your preference by giving comment on issue page on github or send email to the people of maintenance which you can find in the file named with package.xml.
+
 ## Name and Extension Version
 Extension name: **mysqlnd_azure**
 
@@ -10,10 +23,10 @@ Valid version:
 - 1.0.0  Change: initial version. Limitation: cannot install with pecl on linux; cannot work with 7.2.23+ and 7.3.10+
 - 1.0.1  Change: with pecl install command line support on linux. Limitation: cannot work with 7.2.23+ and 7.3.10+
 - 1.0.2  Change: fix compatibility problem with  7.2.23+ and 7.3.10+
-- 1.0.3  Change: In preious versions, if connection doesnot use SSL, or server doesnot support redirection, or redirected connection fails to connect for some reason, it will fallback to the first proxy connection. Since 1.0.3, the logic changes as follows: 
+- 1.1.0Beta  Change: In preious versions, if connection does not use SSL, or server does not support redirection, or redirected connection fails to connect for some reason, it will fallback to the first proxy connection. Since 1.0.3, the logic changes as follows: 
 	1. If redirection is on, ssl is off, no connection will be made, return error "mysqlnd_azure.enableRedirect is on, but SSL option is not set. Redirection is only possible with SSL."
 	2. If redirection is on, but on server side redirection is not available, and there is no last message in OK packet, abort the first connection and return error "No redirection information available, redirection is not possible. Abort the connection."
-	3. If redirected connection failed, also abort the first gateway connection. Return the error of the redirected connection.
+	3. If redirected connection failed, also abort the first proxy connection. Return the error of the redirected connection.
 	4. The option mysqlnd_azure.enabled is also renamed to mysqlnd_azure.enableRedirect.
 
 Following is a brief guide of how to install using pecl or build and test the extension from source. 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Then you can run **make install** to put the .so to your php so library. However
   - put mysqlnd_azure.so under extension_dir.
   - under directory for additional .ini files, you will find the ini files for the common used modules, e.g. 10-mysqlnd.ini for mysqlnd, 20-mysqli.ini for mysqli. Create a new ini file for mysqlnd_azure here. **Make sure the alphabet order of the name is after that of mysqnld**, since the modules are loaded according to the name order of the ini files. E.g. if mysqlnd ini is with name 10-mysqlnd.ini,then name the ini as 20-mysqlnd-azure.ini. In the ini file, add the following two lines:
       - extension=mysqlnd_azure
-      - mysqlnd_azure.enabled = on  ; you can also set this to off to disable redirection
+      - mysqlnd_azure.enableRedirect = on  ; you can also set this to off to disable redirection
 
 
 ## Step to build on Windows
@@ -131,14 +131,14 @@ After this, the code directory should look like C:\php-sdk\phpdev\vc15\x64\php-s
     	- extension=mysqlnd_azure
     - Under the Module Settings section add:
     	- [mysqlnd_azure]
-    	- mysqlnd_azure.enabled = on
+    	- mysqlnd_azure.enableRedirect = on
 
 
 ## Test
 * Currently redirection is only possible when the connection is via ssl, and it need that the redirection feature switch is enabled on server side. Following is a snippet to test connection with redirection:
 
 ```php
-  echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
+  echo "mysqlnd_azure.enableRedirect: ", ini_get("mysqlnd_azure.enableRedirect") == true?"On":"Off", "\n";
   $db = mysqli_init();
   $link = mysqli_real_connect ($db, 'your-hostname-with-redirection-enabled', 'user@host', 'password', "db", 3306, NULL, MYSQLI_CLIENT_SSL);
   if (!$link) {

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ The source code here is a PHP extension implemented using mysqlnd plugin API (ht
 
 In 1.0.x versions, if connection does not use SSL, or server does not support redirection, or redirected connection fails to connect for any non-fatal reason while the proxy connection is still a valid one, it will fallback to the first proxy connection. 
 
-Since 1.1.0Beta, the logic changes as follows:
+Since 1.1.0beta1, the logic changes as follows:
 - If redirection is on, ssl is off, no connection will be made, it will return error "mysqlnd_azure.enableRedirect is on, but SSL option is not set. Redirection is only possible with SSL."
 - If redirection is on, but on server side redirection is not supported/needed (e.g. a community verion mysql installed locally), and there is no last message in OK packet, it will abort the first connection and return error "No redirection information available, redirection is not possible. Abort the connection."
 - If redirected connection failed for any reason, it will also abort the first proxy connection, and return the error of the redirected connection.
 
 ```
 Ask from you:
-In version 1.1.0Beta, we add many restrictions when the feature is turned on, but fallback is then not possible anymore. We also want to hear from you that given the following two options, what will you prefer:
+In version 1.1.0beta1, we add many restrictions when the feature is turned on, but fallback is then not possible anymore. We also want to hear from you that given the following two options, what will you prefer:
  1. Add another option with name "preferred" with fallback support (i.e. go without redirection if SSL is not used, or server does not support redirection, or server does not need redirection).
  2. Remove the restrictions when redrection is turned on, still use the fallback logic as a single solution (i.e. redirect when posssible, and go without redirection if SSL is not used, or server does not support redirection, or server does not need redirection).
 
@@ -109,7 +109,7 @@ Then you can run **make install** to put the .so to your php so library. However
   - under directory for additional .ini files, you will find the ini files for the common used modules, e.g. 10-mysqlnd.ini for mysqlnd, 20-mysqli.ini for mysqli. Create a new ini file for mysqlnd_azure here. **Make sure the alphabet order of the name is after that of mysqnld**, since the modules are loaded according to the name order of the ini files. E.g. if mysqlnd ini is with name 10-mysqlnd.ini,then name the ini as 20-mysqlnd-azure.ini. In the ini file, add the following two lines:
       - extension=mysqlnd_azure
       - mysqlnd_azure.enableRedirect = on  ; you can also set this to off to disable redirection. 
-      	- **Notice:** since 1.0.3, if this value is set to on, the connection must be configured with SSL, and it requires server support redirection. Otherwise, the connection will fail.
+      	- **Notice:** since 1.1.0beta1, if this value is set to on, the connection must be configured with SSL, and it requires server support redirection. Otherwise, the connection will fail.
 
 
 ## Step to build on Windows
@@ -156,7 +156,7 @@ After this, the code directory should look like C:\php-sdk\phpdev\vc15\x64\php-s
     - Under the Module Settings section add:
     	- [mysqlnd_azure]
     	- mysqlnd_azure.enableRedirect = on
-			- **Notice:** since 1.0.3, if this value is set to on, the connection must be configured with SSL, and it requires server support redirection. Otherwise, the connection will fail.
+			- **Notice:** since 1.1.0beta1, if this value is set to on, the connection must be configured with SSL, and it requires server support redirection. Otherwise, the connection will fail.
 
 
 ## Test

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ After this, the code directory should look like C:\php-sdk\phpdev\vc15\x64\php-s
     - Under the Module Settings section add:
     	- [mysqlnd_azure]
     	- mysqlnd_azure.enableRedirect = on
-		- **Notice:** since 1.0.3, if this value is set to on, the connection must be configured with SSL, and it requires server support redirection. Otherwise, the connection will fail.
+			- **Notice:** since 1.0.3, if this value is set to on, the connection must be configured with SSL, and it requires server support redirection. Otherwise, the connection will fail.
 
 
 ## Test

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Since 1.1.0Beta, the logic changes as follows:
 ```
 Ask from you:
 In version 1.1.0Beta, we add many restrictions when the feature is turned on, but fallback is then not possible anymore. We also want to hear from you that given the following two options, what will you prefer:
- 1. Add another option "preferred" with fallback support (i.e. go without redirection if SSL is not used or server does not support redirection or do not need redirection).
- 2. Remove the restrictions when redrection is turned on, still go without redirection if SSL is not used or server does not support redirection or do not need redirection.
+ 1. Add another option with name "preferred" with fallback support (i.e. go without redirection if SSL is not used, or server does not support redirection, or server does not need redirection).
+ 2. Remove the restrictions when redrection is turned on, still use the fallback logic as a single solution (i.e. redirect when posssible, and go without redirection if SSL is not used, or server does not support redirection, or server does not need redirection).
 
 You may vote for your preference by giving comment on issue page on github or send email to the people of maintenance which you can find in the file named with package.xml.
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ In 1.0.x versions, if connection does not use SSL, or server does not support re
 
 Since 1.1.0Beta, the logic changes as follows:
 - If redirection is on, ssl is off, no connection will be made, it will return error "mysqlnd_azure.enableRedirect is on, but SSL option is not set. Redirection is only possible with SSL."
-- If redirection is on, but on server side redirection is not available (e.g. a community verion mysql installed locally), it will abort the first connection and return error "No redirection information available, redirection is not possible. Abort the connection."
+- If redirection is on, but on server side redirection is not supported/needed (e.g. a community verion mysql installed locally), and there is no last message in OK packet, it will abort the first connection and return error "No redirection information available, redirection is not possible. Abort the connection."
 - If redirected connection failed for any reason, it will also abort the first proxy connection, and return the error of the redirected connection.
 
 ```
@@ -28,10 +28,10 @@ Valid version:
 - 1.0.0  Change: initial version. Limitation: cannot install with pecl on linux, the package on PECL website is invalid, only possible to install with manual compilation on Linux. Cannot work with 7.2.23+ and 7.3.10+
 - 1.0.1  Change: with pecl install command line support on linux. Limitation: cannot work with 7.2.23+ and 7.3.10+
 - 1.0.2  Change: fix compatibility problem with  7.2.23+ and 7.3.10+
-- 1.1.0Beta  Change: In preious versions, if connection does not use SSL, or server does not support redirection, or redirected connection fails to connect for some reason, it will fallback to the first proxy connection. Since 1.0.3, the logic changes as follows: 
+- 1.1.0Beta  Change: In 1.0.x versions, if connection does not use SSL, or server does not support redirection, or redirected connection fails to connect for any non-fatal reason while the proxy connection is still a valid one, it will fallback to the first proxy connection. Since 1.1.0Beta, the logic changes as follows: 
 	1. If redirection is on, ssl is off, no connection will be made, return error "mysqlnd_azure.enableRedirect is on, but SSL option is not set. Redirection is only possible with SSL."
-	2. If redirection is on, but on server side redirection is not available, and there is no last message in OK packet, abort the first connection and return error "No redirection information available, redirection is not possible. Abort the connection."
-	3. If redirected connection failed, also abort the first proxy connection. Return the error of the redirected connection.
+	2. If redirection is on, but on server side redirection is not supported/needed, and there is no last message in OK packet, abort the first connection and return error "No redirection information available, redirection is not possible. Abort the connection."
+	3. If redirected connection failed for any reason, it will also abort the first proxy connection, and return the error of the redirected connection.
 	4. The option mysqlnd_azure.enabled is also renamed to mysqlnd_azure.enableRedirect.
 
 Following is a brief guide of how to install using pecl or build and test the extension from source. 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,23 @@
 # PHP mysqlnd redirection extension mysqlnd_azure
 The source code here is a PHP extension implemented using mysqlnd plugin API (https://www.php.net/manual/en/mysqlnd.plugin.php), which provides redirection feature support.  The extension is also available on PECL website at  https://pecl.php.net/package/mysqlnd_azure.
 
-Please notice that there is a limitation that redirection is only possible when the connection is configured with SSL.
-In 1.0.x versions, if connection does not use SSL, or server does not support redirection, or redirected connection fails to connect for some reason, 
-it will fallback to the first proxy connection. Since 1.1.0Beta, the logic changes as follows:
- 	1. If redirection is on, ssl is off, no connection will be made, it will return error "mysqlnd_azure.enableRedirect is on, but SSL option is not set. Redirection is only possible with SSL."
-	2. If redirection is on, but on server side redirection is not available (e.g. a community verion mysql installed locally), it will abort the first connection and return error "No redirection information available, redirection is not possible. Abort the connection."
-	3. If redirected connection failed for any reason, it will also abort the first proxy connection, and return the error of the redirected connection.
-Ask from you: in version 1.1.0Beta, we add many restrictions when the feature is turned on, but fallback is then not possible any more. We also want to hear from you that given the 
-              following two options, what will you prefer:
-              1. Add another option "preferred" with fallback support (i.e. go without redirection if SSL is not used or server doesnot support redirection or do not need redirection).
-              2. Remove the restrictions when redrection is turned on, still go without redirection if SSL is not used or server doesnot support redirection or do not need redirection. 
-              
-              You may vote for your preference by giving comment on issue page on github or send email to the people of maintenance which you can find in the file named with package.xml.
+**Important notice:** There is a limitation that for Azure MySQL, redirection is only possible when the connection is configured with SSL.
+
+In 1.0.x versions, if connection does not use SSL, or server does not support redirection, or redirected connection fails to connect for any non-fatal reason while the proxy connection is still a valid one, it will fallback to the first proxy connection. 
+
+Since 1.1.0Beta, the logic changes as follows:
+- If redirection is on, ssl is off, no connection will be made, it will return error "mysqlnd_azure.enableRedirect is on, but SSL option is not set. Redirection is only possible with SSL."
+- If redirection is on, but on server side redirection is not available (e.g. a community verion mysql installed locally), it will abort the first connection and return error "No redirection information available, redirection is not possible. Abort the connection."
+- If redirected connection failed for any reason, it will also abort the first proxy connection, and return the error of the redirected connection.
+
+```
+Ask from you:
+In version 1.1.0Beta, we add many restrictions when the feature is turned on, but fallback is then not possible any +more. We also want to hear from you that given the following two options, what will you prefer:
+ 1. Add another option "preferred" with fallback support (i.e. go without redirection if SSL is not used or server doesnot support +redirection or do not need redirection).
+ 2. Remove the restrictions when redrection is turned on, still go without redirection if SSL is not used or server doesnot support redirection or do not need redirection. 
+
+You may vote for your preference by giving comment on issue page on github or send email to the people of maintenance which you can find in the file named with package.xml.
+```
 
 ## Name and Extension Version
 Extension name: **mysqlnd_azure**

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ Valid version:
 - 1.0.0  Change: initial version. Limitation: cannot install with pecl on linux; cannot work with 7.2.23+ and 7.3.10+
 - 1.0.1  Change: with pecl install command line support on linux. Limitation: cannot work with 7.2.23+ and 7.3.10+
 - 1.0.2  Change: fix compatibility problem with  7.2.23+ and 7.3.10+
+- 1.0.3  Change: 
+	1. Enfore ssl when using redirection.
+	2. Enfore server support redrection if using redirection.
+	3. If redirected connection failed, also abort the first gateway connection. Return the error of the redirected connection.
+	4. Rename option mysqlnd_azure.enabled to mysqlnd_azure.enableRedirect.
 
 Following is a brief guide of how to install using pecl or build and test the extension from source. 
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # PHP mysqlnd redirection extension mysqlnd_azure
 The source code here is a PHP extension implemented using mysqlnd plugin API (https://www.php.net/manual/en/mysqlnd.plugin.php), which provides redirection feature support.  The extension is also available on PECL website at  https://pecl.php.net/package/mysqlnd_azure.
-
-**Important notice:** There is a limitation that for Azure MySQL, redirection is only possible when the connection is configured with SSL.
-
+```diff
+!**Important notice:** There is a limitation that for Azure MySQL, redirection is only possible when the connection is configured with SSL.
+```
 In 1.0.x versions, if connection does not use SSL, or server does not support redirection, or redirected connection fails to connect for any non-fatal reason while the proxy connection is still a valid one, it will fallback to the first proxy connection. 
 
 Since 1.1.0beta1, the logic changes as follows:

--- a/mysqlnd_azure.c
+++ b/mysqlnd_azure.c
@@ -323,62 +323,76 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
 				DBG_INF_FMT("[redirect]: redirect host=%s user=%s port=%s ", redirect_host, redirect_user, redirect_port);
 
 				ret = set_redirect_client_options(conn, redirect_conn);
+
+                //Close the first connection first before establish the redirected connection
+                conn->m->send_close(conn);
+			    conn->m->dtor(conn);
+				pfc = NULL;
+			    if (transport.s) {
+				    mnd_sprintf_free(transport.s);
+					transport.s = NULL;
+				}
+
 				if (ret == FAIL) { //init redirect_conn failed
 					redirect_conn->m->dtor(redirect_conn);
-					DBG_ENTER("[redirect]: mysql redirect fails to copy MYSQLND_CONN_DATA, use original connection information!");
+                    php_error_docref(NULL, E_ERROR, "[redirect]: mysql redirect fails to copy MYSQLND_CONN_DATA. Abort the connection.");
+                    DBG_RETURN(FAIL);
 				}
 				else { //init redirect_conn succeeded, use this conn to start a new connection and handshake
+
 					MYSQLND_CSTRING redirect_hostname = { redirect_host, strlen(redirect_host) };
 					MYSQLND_CSTRING redirect_username = { redirect_user, strlen(redirect_user) };
 					MYSQLND_STRING redirect_transport = redirect_conn->m->get_scheme(redirect_conn, redirect_hostname, &socket_or_pipe, ui_redirect_port, &unix_socket, &named_pipe);
 					const MYSQLND_CSTRING redirect_scheme = { redirect_transport.s, redirect_transport.l };
 
+                    //upate conn, transport,  pconn for later user
+                    conn = redirect_conn;
+					transport = redirect_transport;
+                    pfc = redirect_conn->protocol_frame_codec;
+					*pconn = redirect_conn; //use new conn outside for caller
+
 					mysqlnd_azure_set_is_using_redirect(redirect_conn, 1);
 
 					enum_func_status redirectState = redirect_conn->m->connect_handshake(redirect_conn, &redirect_scheme, &redirect_username, &password, &database, mysql_flags);
 
-					if (redirectState == FAIL) { //handshake with new redirection MYSQLND_CONN_DATA failed, release resource and use original connection
-						redirect_conn->m->dtor(redirect_conn);
-						if (redirect_transport.s) {
-							mnd_sprintf_free(redirect_transport.s);
-							redirect_transport.s = NULL;
-						}
-						DBG_ENTER("[redirect]: mysql redirect handshake fails, use original connection information!");
-					}
-					else { //handshake with redirect_conn succeeded, close and release resource of original conn and replace it with redirect_conn
+					if (redirectState == PASS) { //handshake with redirect_conn succeeded, replace original connection info with redirect_conn
 
 						//add the redirect info into cache table
-						mysqlnd_azure_add_redirect_cache(conn, username.s, hostname.s, port, redirect_username.s, redirect_hostname.s, ui_redirect_port);
-
-						conn->m->send_close(conn);
-						conn->m->dtor(conn);
-						pfc = NULL;
-						//upate conn, transport,  pconn for later user
-						conn = redirect_conn;
-						if (transport.s) {
-							mnd_sprintf_free(transport.s);
-							transport.s = NULL;
-						}
-						transport = redirect_transport;
-						*pconn = redirect_conn; //use new conn outside for caller
+						mysqlnd_azure_add_redirect_cache(redirect_conn->persistent, username.s, hostname.s, port, redirect_username.s, redirect_hostname.s, ui_redirect_port);
 
 						///upate host, user, pfc for later user
 						hostname = redirect_hostname;
 						username = redirect_username;
 						port = ui_redirect_port;
-						pfc = redirect_conn->protocol_frame_codec;
 
 						DBG_ENTER("[redirect]: mysql redirect handshake succeeded.");
 					}
+                    else {
+                        goto err;
+                    }
 				}
 			}
 			else {
 				DBG_ENTER("[redirect]: redirection info are equal to origin, no need to redirect");
 			}
 		}
-		else {
-			DBG_ENTER("[redirect]: already use redirection info or can not find redirection location in ok packet");
+		else if (!(*pdata)->is_using_redirect) {
+            //If there is no redirection information contained in the last_message, then redirection is not possible. In this case, abort the connection
+            php_error_docref(NULL, E_ERROR, "No redirection information available, redirection is not possible. Abort the connection.");
+            conn->m->send_close(conn);
+			conn->m->dtor(conn);
+            pfc = NULL;
+
+			if (transport.s) {
+				mnd_sprintf_free(transport.s);
+			    transport.s = NULL;
+			}
+
+            DBG_RETURN(FAIL);
 		}
+        else {
+            DBG_ENTER("[redirect]: already use redirection info.");
+        }
 	}
 	/*end of Azure Redirection Logic*/
 
@@ -534,15 +548,22 @@ MYSQLND_METHOD(mysqlnd_azure, connect)(MYSQLND * conn_handle,
 			mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_server_host", hostname.s);
 		}
 
-		if(!MYSQLND_AZURE_G(enabled)) {
+		if(!MYSQLND_AZURE_G(enableRedirect)) {
 			DBG_ENTER("mysqlnd_azure::connect redirect disabled");
 			ret = org_conn_d_m.connect(*pconn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);
 		}
 		else {
 			DBG_ENTER("mysqlnd_azure::connect redirect enabled");
 
+            //Redirection is only possible with SSL
+            unsigned int temp_flags = (*pconn)->m->get_updated_connect_flags(*pconn, mysql_flags);
+            if(!(temp_flags & CLIENT_SSL)) {
+                php_error_docref(NULL, E_ERROR, "mysqlnd_azure.enableRedirect is on, but SSL option is not set. Redirection is only possible with SSL.");
+                DBG_RETURN(FAIL);
+            }
+
 			//first check whether the redirect info already cached
-			MYSQLND_AZURE_REDIRECT_INFO* redirect_info = mysqlnd_azure_find_redirect_cache(*pconn, username.s, hostname.s, port);
+			MYSQLND_AZURE_REDIRECT_INFO* redirect_info = mysqlnd_azure_find_redirect_cache(username.s, hostname.s, port);
 			if (redirect_info != NULL) {
 				DBG_ENTER("mysqlnd_azure::connect try the cached info first");
 				MYSQLND_CSTRING redirect_host = { redirect_info->redirect_host, strlen(redirect_info->redirect_host) };
@@ -552,7 +573,7 @@ MYSQLND_METHOD(mysqlnd_azure, connect)(MYSQLND * conn_handle,
 				ret = (*pconn)->m->connect(pconn, redirect_host, redirect_user, password, database, redirect_info->redirect_port, socket_or_pipe, mysql_flags);
 				if (ret == FAIL) {
 					//remove invalid cache
-					mysqlnd_azure_remove_redirect_cache(*pconn, username.s, hostname.s, port);
+					mysqlnd_azure_remove_redirect_cache(username.s, hostname.s, port);
 
 					mysqlnd_azure_set_is_using_redirect(*pconn, 0);
 					ret = (*pconn)->m->connect(pconn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);

--- a/mysqlnd_azure.c
+++ b/mysqlnd_azure.c
@@ -355,7 +355,7 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
 
 					enum_func_status redirectState = redirect_conn->m->connect_handshake(redirect_conn, &redirect_scheme, &redirect_username, &password, &database, mysql_flags);
 
-					if (redirectState == PASS) { //handshake with redirect_conn succeeded, replace original connection info with redirect_conn
+					if (redirectState == PASS) { //handshake with redirect_conn succeeded, replace original connection info with redirect_conn and add the redirect info into cache table
 
 						//add the redirect info into cache table
 						mysqlnd_azure_add_redirect_cache(redirect_conn->persistent, username.s, hostname.s, port, redirect_username.s, redirect_hostname.s, ui_redirect_port);

--- a/mysqlnd_azure.c
+++ b/mysqlnd_azure.c
@@ -335,7 +335,7 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
 
 				if (ret == FAIL) { //init redirect_conn failed
 					redirect_conn->m->dtor(redirect_conn);
-                    php_error_docref(NULL, E_ERROR, "[redirect]: mysql redirect fails to copy MYSQLND_CONN_DATA. Abort the connection.");
+                    php_error_docref(NULL, E_WARNING, "[redirect]: mysql redirect fails to copy MYSQLND_CONN_DATA. Abort the connection.");
                     DBG_RETURN(FAIL);
 				}
 				else { //init redirect_conn succeeded, use this conn to start a new connection and handshake
@@ -378,7 +378,7 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
 		}
 		else if (!(*pdata)->is_using_redirect) {
             //If there is no redirection information contained in the last_message, then redirection is not possible. In this case, abort the connection
-            php_error_docref(NULL, E_ERROR, "Abort the connection because MySQL server does not enable redirection or network package doesn't meet redirection protocol.");
+            php_error_docref(NULL, E_WARNING, "Abort the connection because MySQL server does not enable redirection or network package doesn't meet redirection protocol.");
             conn->m->send_close(conn);
 			conn->m->dtor(conn);
             pfc = NULL;
@@ -558,7 +558,7 @@ MYSQLND_METHOD(mysqlnd_azure, connect)(MYSQLND * conn_handle,
             //Redirection is only possible with SSL
             unsigned int temp_flags = (*pconn)->m->get_updated_connect_flags(*pconn, mysql_flags);
             if(!(temp_flags & CLIENT_SSL)) {
-                php_error_docref(NULL, E_ERROR, "mysqlnd_azure.enableRedirect is on, but SSL option is not set. Redirection is only possible with SSL.");
+                php_error_docref(NULL, E_WARNING, "mysqlnd_azure.enableRedirect is on, but SSL option is not set. Redirection is only possible with SSL.");
                 DBG_RETURN(FAIL);
             }
 

--- a/mysqlnd_azure.c
+++ b/mysqlnd_azure.c
@@ -367,7 +367,7 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
 
 						DBG_ENTER("[redirect]: mysql redirect handshake succeeded.");
 					}
-                    else {
+                    else { //redirect failed
                         goto err;
                     }
 				}

--- a/mysqlnd_azure.c
+++ b/mysqlnd_azure.c
@@ -378,7 +378,7 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
 		}
 		else if (!(*pdata)->is_using_redirect) {
             //If there is no redirection information contained in the last_message, then redirection is not possible. In this case, abort the connection
-            php_error_docref(NULL, E_ERROR, "No redirection information available, redirection is not possible. Abort the connection.");
+            php_error_docref(NULL, E_ERROR, "Abort the connection because MySQL server does not enable redirection or network package doesn't meet redirection protocol.");
             conn->m->send_close(conn);
 			conn->m->dtor(conn);
             pfc = NULL;

--- a/mysqlnd_azure.h
+++ b/mysqlnd_azure.h
@@ -46,9 +46,9 @@ void mysqlnd_azure_minit_register_hooks();
 
 MYSQLND_AZURE_CONN_DATA** mysqlnd_azure_get_is_using_redirect(const MYSQLND_CONN_DATA *conn);
 MYSQLND_AZURE_CONN_DATA** mysqlnd_azure_set_is_using_redirect(MYSQLND_CONN_DATA *conn, zend_bool is_using_redirect);
-enum_func_status mysqlnd_azure_add_redirect_cache(const MYSQLND_CONN_DATA* conn, const char* user, const char* host, int port, const char* redirect_user, const char* redirect_host, int redirect_port);
-enum_func_status mysqlnd_azure_remove_redirect_cache(const MYSQLND_CONN_DATA* conn, const char* user, const char* host, int port);
-MYSQLND_AZURE_REDIRECT_INFO* mysqlnd_azure_find_redirect_cache(const MYSQLND_CONN_DATA* conn, const char* user, const char* host, int port);
+enum_func_status mysqlnd_azure_add_redirect_cache(zend_bool persistent, const char* user, const char* host, int port, const char* redirect_user, const char* redirect_host, int redirect_port);
+enum_func_status mysqlnd_azure_remove_redirect_cache(const char* user, const char* host, int port);
+MYSQLND_AZURE_REDIRECT_INFO* mysqlnd_azure_find_redirect_cache(const char* user, const char* host, int port);
 
 #if defined(ZTS) && defined(COMPILE_DL_MYSQLND_AZURE)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/package.xml
+++ b/package.xml
@@ -19,19 +19,19 @@
  <date>2019-11-26</date>
  <time>14:00:13</time>
  <version>
-  <release>1.0.3</release>
-  <api>1.0.3</api>
+  <release>1.1.0Beta</release>
+  <api>1.1.0Beta</api>
  </version>
  <stability>
-  <release>stable</release>
-  <api>stable</api>
+  <release>Beta</release>
+  <api>Beta</api>
  </stability>
  <license uri="http://www.php.net/license">PHP License</license>
  <notes>
-- 1. If redirection is on, ssl is off, no connection will be made, return error "mysqlnd_azure.enableRedirect is on, but SSL option is not set. Redirection is only possible with SSL."
-- 2. If redirection is on, but on server side redirection is not available, and there is no last message in OK packet, abort the first connection and return error "No redirection information available, redirection is not possible. Abort the connection."
-- 3. If redirected connection failed, also abort the first gateway connection. Return the error of the redirected connection.
-- 4. Rename option mysqlnd_azure.enabled to mysqlnd_azure.enableRedirect.
+- 1. Rename option mysqlnd_azure.enabled to mysqlnd_azure.enableRedirect.
+- 2. If enableRedirect is on, ssl is off, no connection will be made, return error "mysqlnd_azure.enableRedirect is on, but SSL option is not set. Redirection is only possible with SSL."
+- 3. If enableRedirect is on, but on server side redirection is not available, and there is no last message in OK packet, abort the first connection and return error "No redirection information available, redirection is not possible. Abort the connection."
+- 4. If enableRedirect is on and server supports redirection, but the redirected connection failed for any reason, also abort the first proxy connection. Return the error of the redirected connection.
  </notes>
  <contents>
   <dir name="/">
@@ -70,20 +70,20 @@
  <changelog>
    <release>
     <version>
-    <release>1.0.3</release>
-    <api>1.0.3</api>
+    <release>1.1.0Beta</release>
+    <api>1.1.0Beta</api>
     </version>
     <stability>
-      <release>stable</release>
-      <api>stable</api>
+      <release>Beta</release>
+      <api>Beta</api>
     </stability>
    <date>2019-11-26</date>
    <license uri="http://www.php.net/license">PHP License</license>
    <notes>
-- 1. If redirection is on, ssl is off, no connection will be made, return error "mysqlnd_azure.enableRedirect is on, but SSL option is not set. Redirection is only possible with SSL."
-- 2. If redirection is on, but on server side redirection is not available, and there is no last message in OK packet, abort the first connection and return error "No redirection information available, redirection is not possible. Abort the connection."
-- 3. If redirected connection failed, also abort the first gateway connection. Return the error of the redirected connection.
-- 4. Rename option mysqlnd_azure.enabled to mysqlnd_azure.enableRedirect.
+- 1. Rename option mysqlnd_azure.enabled to mysqlnd_azure.enableRedirect.
+- 2. If enableRedirect is on, ssl is off, no connection will be made, return error "mysqlnd_azure.enableRedirect is on, but SSL option is not set. Redirection is only possible with SSL."
+- 3. If enableRedirect is on, but on server side redirection is not available, and there is no last message in OK packet, abort the first connection and return error "No redirection information available, redirection is not possible. Abort the connection."
+- 4. If enableRedirect is on and server supports redirection, but the redirected connection failed for any reason, also abort the first proxy connection. Return the error of the redirected connection.
    </notes>
   </release>
    <release>

--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,7 @@
   <email>Qianqian.Bu@microsoft.com</email>
   <active>yes</active>
  </lead>
- <date>2019-11-26</date>
+ <date>2019-12-05</date>
  <time>14:00:13</time>
  <version>
   <release>1.1.0beta1</release>
@@ -77,7 +77,7 @@
       <release>beta</release>
       <api>beta</api>
     </stability>
-   <date>2019-11-26</date>
+   <date>2019-12-05</date>
    <license uri="http://www.php.net/license">PHP License</license>
    <notes>
 - 1. Rename option mysqlnd_azure.enabled to mysqlnd_azure.enableRedirect.

--- a/package.xml
+++ b/package.xml
@@ -16,11 +16,11 @@
   <email>Qianqian.Bu@microsoft.com</email>
   <active>yes</active>
  </lead>
- <date>2019-11-20</date>
- <time>13:00:13</time>
+ <date>2019-11-26</date>
+ <time>14:00:13</time>
  <version>
-  <release>1.0.2</release>
-  <api>1.0.2</api>
+  <release>1.0.3</release>
+  <api>1.0.3</api>
  </version>
  <stability>
   <release>stable</release>
@@ -28,7 +28,10 @@
  </stability>
  <license uri="http://www.php.net/license">PHP License</license>
  <notes>
-- apply fix for database null/empty problem change in https://github.com/php/php-src/pull/4340 in MYSQLND_METHOD(mysqlnd_conn_data, connect) to MYSQLND_METHOD(mysqlnd_azure_data, connect)
+- 1. If redirection is on, ssl is off, no connection will be made, return error "mysqlnd_azure.enableRedirect is on, but SSL option is not set. Redirection is only possible with SSL."
+- 2. If redirection is on, but on server side redirection is not available, and there is no last message in OK packet, abort the first connection and return error "No redirection information available, redirection is not possible. Abort the connection."
+- 3. If redirected connection failed, also abort the first gateway connection. Return the error of the redirected connection.
+- 4. Rename option mysqlnd_azure.enabled to mysqlnd_azure.enableRedirect.
  </notes>
  <contents>
   <dir name="/">
@@ -65,6 +68,24 @@
  <providesextension>mysqlnd_azure</providesextension>
  <extsrcrelease />
  <changelog>
+   <release>
+    <version>
+    <release>1.0.3</release>
+    <api>1.0.3</api>
+    </version>
+    <stability>
+      <release>stable</release>
+      <api>stable</api>
+    </stability>
+   <date>2019-11-26</date>
+   <license uri="http://www.php.net/license">PHP License</license>
+   <notes>
+- 1. If redirection is on, ssl is off, no connection will be made, return error "mysqlnd_azure.enableRedirect is on, but SSL option is not set. Redirection is only possible with SSL."
+- 2. If redirection is on, but on server side redirection is not available, and there is no last message in OK packet, abort the first connection and return error "No redirection information available, redirection is not possible. Abort the connection."
+- 3. If redirected connection failed, also abort the first gateway connection. Return the error of the redirected connection.
+- 4. Rename option mysqlnd_azure.enabled to mysqlnd_azure.enableRedirect.
+   </notes>
+  </release>
    <release>
     <version>
     <release>1.0.2</release>

--- a/package.xml
+++ b/package.xml
@@ -19,12 +19,12 @@
  <date>2019-11-26</date>
  <time>14:00:13</time>
  <version>
-  <release>1.1.0Beta</release>
-  <api>1.1.0Beta</api>
+  <release>1.1.0beta1</release>
+  <api>1.1.0beta1</api>
  </version>
  <stability>
-  <release>Beta</release>
-  <api>Beta</api>
+  <release>beta</release>
+  <api>beta</api>
  </stability>
  <license uri="http://www.php.net/license">PHP License</license>
  <notes>
@@ -70,12 +70,12 @@
  <changelog>
    <release>
     <version>
-    <release>1.1.0Beta</release>
-    <api>1.1.0Beta</api>
+    <release>1.1.0beta1</release>
+    <api>1.1.0beta1</api>
     </version>
     <stability>
-      <release>Beta</release>
-      <api>Beta</api>
+      <release>beta</release>
+      <api>beta</api>
     </stability>
    <date>2019-11-26</date>
    <license uri="http://www.php.net/license">PHP License</license>

--- a/php_mysqlnd_azure.c
+++ b/php_mysqlnd_azure.c
@@ -40,10 +40,10 @@ static PHP_GINIT_FUNCTION(mysqlnd_azure)
 
 /* {{{ PHP_INI */
 /*
-	It is handy to allow users to disable any mysqlnd plugin globally - not only for debugging :-)
+	It is handy to allow users to set the value for debug and other behavior check purpose)
 */
 PHP_INI_BEGIN()
-STD_PHP_INI_ENTRY("mysqlnd_azure.enableRedirect", "0", PHP_INI_PERDIR, OnUpdateBool, enableRedirect, zend_mysqlnd_azure_globals, mysqlnd_azure_globals)
+STD_PHP_INI_ENTRY("mysqlnd_azure.enableRedirect", "0", PHP_INI_ALL, OnUpdateBool, enableRedirect, zend_mysqlnd_azure_globals, mysqlnd_azure_globals)
 PHP_INI_END()
 /* }}} */
 

--- a/php_mysqlnd_azure.c
+++ b/php_mysqlnd_azure.c
@@ -34,7 +34,7 @@ static PHP_GINIT_FUNCTION(mysqlnd_azure)
 #if defined(COMPILE_DL_MYSQLND_AZURE) && defined(ZTS)
 	ZEND_TSRMLS_CACHE_UPDATE();
 #endif
-	mysqlnd_azure_globals->enabled = 0;
+	mysqlnd_azure_globals->enableRedirect = 0;
 	mysqlnd_azure_globals->redirectCache = NULL;
 }
 /* }}} */
@@ -53,11 +53,11 @@ static PHP_GSHUTDOWN_FUNCTION(mysqlnd_azure)
 /* {{{ PHP_INI */
 /*
 	It is handy to allow users to disable any mysqlnd plugin globally - not only for debugging :-)
-	Because we register our plugin in MINIT changes to mysqlnd_ed.enabled shall be bound to
+	Because we register our plugin in MINIT changes to myqlnd_azure.enableRedirect shall be bound to
 	INI_SYSTEM (and PHP restarts).
 */
 PHP_INI_BEGIN()
-STD_PHP_INI_ENTRY("mysqlnd_azure.enabled", "0", PHP_INI_ALL, OnUpdateBool, enabled, zend_mysqlnd_azure_globals, mysqlnd_azure_globals)
+STD_PHP_INI_ENTRY("mysqlnd_azure.enableRedirect", "0", PHP_INI_ALL, OnUpdateBool, enableRedirect, zend_mysqlnd_azure_globals, mysqlnd_azure_globals)
 PHP_INI_END()
 /* }}} */
 
@@ -87,8 +87,8 @@ static PHP_MSHUTDOWN_FUNCTION(mysqlnd_azure)
 PHP_MINFO_FUNCTION(mysqlnd_azure)
 {
 	php_info_print_table_start();
-	php_info_print_table_header(2, "mysqlnd_azure", "enabled");
-	php_info_print_table_row(2, "enabled", MYSQLND_AZURE_G(enabled)? "Yes":"No");
+	php_info_print_table_header(2, "mysqlnd_azure", "enableRedirect");
+	php_info_print_table_row(2, "enableRedirect", MYSQLND_AZURE_G(enableRedirect)? "Yes":"No");
 	php_info_print_table_end();
 }
 /* }}} */

--- a/php_mysqlnd_azure.c
+++ b/php_mysqlnd_azure.c
@@ -41,11 +41,9 @@ static PHP_GINIT_FUNCTION(mysqlnd_azure)
 /* {{{ PHP_INI */
 /*
 	It is handy to allow users to disable any mysqlnd plugin globally - not only for debugging :-)
-	Because we register our plugin in MINIT changes to myqlnd_azure.enableRedirect shall be bound to
-	INI_SYSTEM (and PHP restarts).
 */
 PHP_INI_BEGIN()
-STD_PHP_INI_ENTRY("mysqlnd_azure.enableRedirect", "0", PHP_INI_ALL, OnUpdateBool, enableRedirect, zend_mysqlnd_azure_globals, mysqlnd_azure_globals)
+STD_PHP_INI_ENTRY("mysqlnd_azure.enableRedirect", "0", PHP_INI_PERDIR, OnUpdateBool, enableRedirect, zend_mysqlnd_azure_globals, mysqlnd_azure_globals)
 PHP_INI_END()
 /* }}} */
 
@@ -106,14 +104,14 @@ zend_module_entry mysqlnd_azure_module_entry = {
 	STANDARD_MODULE_HEADER_EX,
 	NULL,
 	mysqlnd_azure_deps,
-	EXT_MYSQLND_AZURE_NAME,
+	PHP_MYSQLND_AZURE_NAME,
 	NULL,
 	PHP_MINIT(mysqlnd_azure),
 	PHP_MSHUTDOWN(mysqlnd_azure),
 	NULL,
 	NULL,
 	PHP_MINFO(mysqlnd_azure),
-	EXT_MYSQLND_AZURE_VERSION,
+	PHP_MYSQLND_AZURE_VERSION,
 	PHP_MODULE_GLOBALS(mysqlnd_azure),
 	PHP_GINIT(mysqlnd_azure),
 	NULL,

--- a/php_mysqlnd_azure.h
+++ b/php_mysqlnd_azure.h
@@ -31,9 +31,20 @@ extern zend_module_entry mysqlnd_azure_module_entry;
 #define EXT_MYSQLND_AZURE_NAME      "mysqlnd_azure"
 #define EXT_MYSQLND_AZURE_VERSION   "1.0.3"
 
+/* true global environment */
+HashTable* redirectCache;
+
+#ifdef ZTS
+/* exclusive locking for redirectCache*/
+void mysqlnd_azure_redirect_cache_lock(void);
+void mysqlnd_azure_redirect_cache_unlock(void);
+void mysqlnd_azure_redirect_cache_lock_alloc(void);
+void mysqlnd_azure_redirect_cache_lock_free(void);
+#endif
+
+
 ZEND_BEGIN_MODULE_GLOBALS(mysqlnd_azure)
 	zend_bool		enableRedirect;
-	HashTable*		redirectCache;
 ZEND_END_MODULE_GLOBALS(mysqlnd_azure)
 
 PHPAPI ZEND_EXTERN_MODULE_GLOBALS(mysqlnd_azure)

--- a/php_mysqlnd_azure.h
+++ b/php_mysqlnd_azure.h
@@ -32,7 +32,7 @@ extern zend_module_entry mysqlnd_azure_module_entry;
 #define EXT_MYSQLND_AZURE_VERSION   "1.0.2"
 
 ZEND_BEGIN_MODULE_GLOBALS(mysqlnd_azure)
-	zend_bool		enabled;
+	zend_bool		enableRedirect;
 	HashTable*		redirectCache;
 ZEND_END_MODULE_GLOBALS(mysqlnd_azure)
 

--- a/php_mysqlnd_azure.h
+++ b/php_mysqlnd_azure.h
@@ -28,8 +28,8 @@
 extern zend_module_entry mysqlnd_azure_module_entry;
 # define phpext_mysqlnd_azure_ptr &mysqlnd_azure_module_entry
 
-#define EXT_MYSQLND_AZURE_NAME      "mysqlnd_azure"
-#define EXT_MYSQLND_AZURE_VERSION   "1.0.3"
+#define PHP_MYSQLND_AZURE_NAME      "mysqlnd_azure"
+#define PHP_MYSQLND_AZURE_VERSION   "1.1.0Beta"
 
 /* true global environment */
 HashTable* redirectCache;

--- a/php_mysqlnd_azure.h
+++ b/php_mysqlnd_azure.h
@@ -29,7 +29,7 @@ extern zend_module_entry mysqlnd_azure_module_entry;
 # define phpext_mysqlnd_azure_ptr &mysqlnd_azure_module_entry
 
 #define PHP_MYSQLND_AZURE_NAME      "mysqlnd_azure"
-#define PHP_MYSQLND_AZURE_VERSION   "1.1.0Beta"
+#define PHP_MYSQLND_AZURE_VERSION   "1.1.0beta1"
 
 /* true global environment */
 HashTable* redirectCache;

--- a/php_mysqlnd_azure.h
+++ b/php_mysqlnd_azure.h
@@ -29,7 +29,7 @@ extern zend_module_entry mysqlnd_azure_module_entry;
 # define phpext_mysqlnd_azure_ptr &mysqlnd_azure_module_entry
 
 #define EXT_MYSQLND_AZURE_NAME      "mysqlnd_azure"
-#define EXT_MYSQLND_AZURE_VERSION   "1.0.2"
+#define EXT_MYSQLND_AZURE_VERSION   "1.0.3"
 
 ZEND_BEGIN_MODULE_GLOBALS(mysqlnd_azure)
 	zend_bool		enableRedirect;

--- a/redirect_cache.c
+++ b/redirect_cache.c
@@ -29,6 +29,43 @@
 #include "ext/mysqlnd/mysqlnd_statistics.h"
 #include "ext/mysqlnd/mysqlnd_connection.h"
 
+#ifdef ZTS
+#include <TSRM/TSRM.h>
+#endif
+
+#ifdef ZTS
+static MUTEX_T redirect_cache_mutex;
+
+/* {{{ mysqlnd_azure_redirect_cache_lock */
+void mysqlnd_azure_redirect_cache_lock(void)
+{
+    tsrm_mutex_lock(redirect_cache_mutex);
+}
+/* }}} */
+
+/* {{{ mysqlnd_azure_redirect_cache_unlock */
+void mysqlnd_azure_redirect_cache_unlock(void)
+{
+    tsrm_mutex_unlock(redirect_cache_mutex);
+}
+/* }}} */
+
+/* {{{ mysqlnd_azure_redirect_cache_lock_alloc */
+void mysqlnd_azure_redirect_cache_lock_alloc(void)
+{
+	redirect_cache_mutex = tsrm_mutex_alloc();
+}
+/* }}} */
+
+/* {{{ mysqlnd_azure_redirect_cache_lock_free */
+void mysqlnd_azure_redirect_cache_lock_free(void)
+{
+	tsrm_mutex_free(redirect_cache_mutex);
+}
+/* }}} */
+
+#endif
+
 /* {{{ mysqlnd_azure_redirect_info_dtor */
 static void mysqlnd_azure_redirect_info_dtor(zval *zv)
 {
@@ -78,12 +115,7 @@ MYSQLND_AZURE_CONN_DATA** mysqlnd_azure_set_is_using_redirect(MYSQLND_CONN_DATA 
 /* {{{ mysqlnd_azure_add_redirect_cache */
 enum_func_status mysqlnd_azure_add_redirect_cache(zend_bool persistent, const char* user, const char* host, int port, const char* redirect_user, const char* redirect_host, int redirect_port)
 {
-	if (MYSQLND_AZURE_G(redirectCache) == NULL) {
-		MYSQLND_AZURE_G(redirectCache) = mnd_pemalloc(sizeof(HashTable), 1);
-		zend_hash_init(MYSQLND_AZURE_G(redirectCache), 0, NULL, mysqlnd_azure_redirect_info_dtor, 1);
-	}
-
-	char *key = NULL;
+    char *key = NULL;
 	mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN+ MAX_REDIRECT_USER_LEN+8, "%s_%s_%d", user, host, port);
 
 	MYSQLND_AZURE_REDIRECT_INFO* redirect_info = pemalloc(sizeof(MYSQLND_AZURE_REDIRECT_INFO), persistent);
@@ -91,9 +123,21 @@ enum_func_status mysqlnd_azure_add_redirect_cache(zend_bool persistent, const ch
 	redirect_info->redirect_host = mnd_pestrndup(redirect_host, strlen(redirect_host), persistent);
 	redirect_info->redirect_port = redirect_port;
 
-	zend_hash_str_update_ptr(MYSQLND_AZURE_G(redirectCache), key, strlen(key), redirect_info);
+    #ifdef ZTS
+    mysqlnd_azure_redirect_cache_lock();
+    #endif
+	if (redirectCache == NULL) {
+		redirectCache = mnd_pemalloc(sizeof(HashTable), 1);
+		zend_hash_init(redirectCache, 0, NULL, mysqlnd_azure_redirect_info_dtor, 1);
+	}
 
-	mnd_sprintf_free(key);
+	zend_hash_str_update_ptr(redirectCache, key, strlen(key), redirect_info);
+
+    #ifdef ZTS
+    mysqlnd_azure_redirect_cache_unlock();
+    #endif
+
+    mnd_sprintf_free(key);
 
     return PASS;
 }
@@ -102,15 +146,21 @@ enum_func_status mysqlnd_azure_add_redirect_cache(zend_bool persistent, const ch
 /* {{{ mysqlnd_azure_remove_redirect_cache */
 enum_func_status mysqlnd_azure_remove_redirect_cache(const char* user, const char* host, int port)
 {
-	if (MYSQLND_AZURE_G(redirectCache) == NULL)
-		return PASS;
+    if(redirectCache != NULL) {
+        char *key = NULL;
+        mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN + MAX_REDIRECT_USER_LEN + 8, "%s_%s_%d", user, host, port);
 
-	char *key = NULL;
-	mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN + MAX_REDIRECT_USER_LEN + 8, "%s_%s_%d", user, host, port);
+        #ifdef ZTS
+        mysqlnd_azure_redirect_cache_lock();
+        #endif
 
-	zend_hash_str_del(MYSQLND_AZURE_G(redirectCache), key, strlen(key));
+        zend_hash_str_del(redirectCache, key, strlen(key));
+        #ifdef ZTS
+        mysqlnd_azure_redirect_cache_unlock();
+        #endif
 
-	mnd_sprintf_free(key);
+        mnd_sprintf_free(key);
+    }
 
 	return PASS;
 }
@@ -119,15 +169,23 @@ enum_func_status mysqlnd_azure_remove_redirect_cache(const char* user, const cha
 /* {{{ mysqlnd_azure_find_redirect_cache */
 MYSQLND_AZURE_REDIRECT_INFO* mysqlnd_azure_find_redirect_cache(const char* user, const char* host, int port)
 {
-	if (MYSQLND_AZURE_G(redirectCache) == NULL)
-		return NULL;
+    if (redirectCache != NULL) {
+        char *key = NULL;
+        mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN + MAX_REDIRECT_USER_LEN + 8, "%s_%s_%d", user, host, port);
 
-	char *key = NULL;
-	mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN + MAX_REDIRECT_USER_LEN + 8, "%s_%s_%d", user, host, port);
+        #ifdef ZTS
+        mysqlnd_azure_redirect_cache_lock();
+        #endif
 
-	void* zv_dest = zend_hash_str_find_ptr(MYSQLND_AZURE_G(redirectCache), key, strlen(key));
-	mnd_sprintf_free(key);
+        void* zv_dest = zend_hash_str_find_ptr(redirectCache, key, strlen(key));
+        #ifdef ZTS
+        mysqlnd_azure_redirect_cache_unlock();
+        #endif
+        mnd_sprintf_free(key);
 
-	return (MYSQLND_AZURE_REDIRECT_INFO*)zv_dest;
+        return (MYSQLND_AZURE_REDIRECT_INFO*)zv_dest;
+    } else {
+        return NULL;
+    }
 }
 /* }}} */

--- a/redirect_cache.c
+++ b/redirect_cache.c
@@ -76,7 +76,7 @@ MYSQLND_AZURE_CONN_DATA** mysqlnd_azure_set_is_using_redirect(MYSQLND_CONN_DATA 
 /* }}} */
 
 /* {{{ mysqlnd_azure_add_redirect_cache */
-enum_func_status mysqlnd_azure_add_redirect_cache(const MYSQLND_CONN_DATA* conn, const char* user, const char* host, int port, const char* redirect_user, const char* redirect_host, int redirect_port)
+enum_func_status mysqlnd_azure_add_redirect_cache(zend_bool persistent, const char* user, const char* host, int port, const char* redirect_user, const char* redirect_host, int redirect_port)
 {
 	if (MYSQLND_AZURE_G(redirectCache) == NULL) {
 		MYSQLND_AZURE_G(redirectCache) = mnd_pemalloc(sizeof(HashTable), 1);
@@ -86,9 +86,9 @@ enum_func_status mysqlnd_azure_add_redirect_cache(const MYSQLND_CONN_DATA* conn,
 	char *key = NULL;
 	mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN+ MAX_REDIRECT_USER_LEN+8, "%s_%s_%d", user, host, port);
 
-	MYSQLND_AZURE_REDIRECT_INFO* redirect_info = pemalloc(sizeof(MYSQLND_AZURE_REDIRECT_INFO), conn->persistent);
-	redirect_info->redirect_user = mnd_pestrndup(redirect_user, strlen(redirect_user), conn->persistent);
-	redirect_info->redirect_host = mnd_pestrndup(redirect_host, strlen(redirect_host), conn->persistent);
+	MYSQLND_AZURE_REDIRECT_INFO* redirect_info = pemalloc(sizeof(MYSQLND_AZURE_REDIRECT_INFO), persistent);
+	redirect_info->redirect_user = mnd_pestrndup(redirect_user, strlen(redirect_user), persistent);
+	redirect_info->redirect_host = mnd_pestrndup(redirect_host, strlen(redirect_host), persistent);
 	redirect_info->redirect_port = redirect_port;
 
 	zend_hash_str_update_ptr(MYSQLND_AZURE_G(redirectCache), key, strlen(key), redirect_info);
@@ -100,7 +100,7 @@ enum_func_status mysqlnd_azure_add_redirect_cache(const MYSQLND_CONN_DATA* conn,
 /* }}} */
 
 /* {{{ mysqlnd_azure_remove_redirect_cache */
-enum_func_status mysqlnd_azure_remove_redirect_cache(const MYSQLND_CONN_DATA* conn, const char* user, const char* host, int port)
+enum_func_status mysqlnd_azure_remove_redirect_cache(const char* user, const char* host, int port)
 {
 	if (MYSQLND_AZURE_G(redirectCache) == NULL)
 		return PASS;
@@ -117,7 +117,7 @@ enum_func_status mysqlnd_azure_remove_redirect_cache(const MYSQLND_CONN_DATA* co
 /* }}} */
 
 /* {{{ mysqlnd_azure_find_redirect_cache */
-MYSQLND_AZURE_REDIRECT_INFO* mysqlnd_azure_find_redirect_cache(const MYSQLND_CONN_DATA* conn, const char* user, const char* host, int port)
+MYSQLND_AZURE_REDIRECT_INFO* mysqlnd_azure_find_redirect_cache(const char* user, const char* host, int port)
 {
 	if (MYSQLND_AZURE_G(redirectCache) == NULL)
 		return NULL;

--- a/tests/mysqli_azure_redirection_disabled.phpt
+++ b/tests/mysqli_azure_redirection_disabled.phpt
@@ -1,7 +1,7 @@
 --TEST--
-Azure redirection test for servers with mysqlnd_azure.enabled=0
+Azure redirection test for servers with mysqlnd_azure.enableRedirect=0
 --INI--
-mysqlnd_azure.enabled=0
+mysqlnd_azure.enableRedirect=0
 --SKIPIF--
 <?php
     require_once('skipif.inc');
@@ -11,8 +11,8 @@ mysqlnd_azure.enabled=0
 <?php
 require_once("connect.inc");
 
-if (($tmp = ini_get("mysqlnd_azure.enabled")) != false)
-		printf("[001] mysqlnd_azure.enabled not set to false, got '%s'\n", $tmp);
+if (($tmp = ini_get("mysqlnd_azure.enableRedirect")) != false)
+		printf("[001] mysqlnd_azure.enableRedirect not set to false, got '%s'\n", $tmp);
 
 $link = mysqli_init();
 $ret = mysqli_real_connect($link, $host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);

--- a/tests/mysqli_azure_redirection_disabled.phpt
+++ b/tests/mysqli_azure_redirection_disabled.phpt
@@ -33,6 +33,6 @@ echo "Done\n";
 ?>
 --EXPECTF--
 %s
-Location: mysql://tr%d.%s:%d/user=%s@%s
+Location: mysql://%s:%d/user=%s@%s
 1
 Done

--- a/tests/mysqli_azure_redirection_enabled.phpt
+++ b/tests/mysqli_azure_redirection_enabled.phpt
@@ -32,7 +32,7 @@ mysqli_close($link);
 echo "Done\n";
 ?>
 --EXPECTF--
-tr%d.%s
-Location: mysql://tr%d.%s:%d/user=%s@%s
+%s
+Location: mysql://%s:%d/user=%s@%s
 0
 Done

--- a/tests/mysqli_azure_redirection_enabled.phpt
+++ b/tests/mysqli_azure_redirection_enabled.phpt
@@ -1,7 +1,7 @@
 --TEST--
-Azure redirection test for servers when mysqlnd_azure.enabled
+Azure redirection test for servers when mysqlnd_azure.enableRedirect
 --INI--
-mysqlnd_azure.enabled=1
+mysqlnd_azure.enableRedirect=1
 --SKIPIF--
 <?php
 require_once('skipif.inc');
@@ -11,8 +11,8 @@ require_once('skipifconnectfailure.inc');
 <?php
 require_once("connect.inc");
 
-if (($tmp = ini_get("mysqlnd_azure.enabled")) != true)
-		printf("[001] mysqlnd_azure.enabled not set to true, got '%s'\n", $tmp);
+if (($tmp = ini_get("mysqlnd_azure.enableRedirect")) != true)
+		printf("[001] mysqlnd_azure.enableRedirect not set to true, got '%s'\n", $tmp);
 
 $link = mysqli_init();
 $ret = mysqli_real_connect($link, $host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);


### PR DESCRIPTION
1. If redirection is on, ssl is off, no connection will be made, give error "mysqlnd_azure.enableRedirect is on, but SSL option is not set. Redirection is only possible with SSL."
2 If redirection is on, on server side, redirection is not available, there is no last message in OK packet, abort the first connection and return error "No redirection information available, redirection is not possible. Abort the connection."
3. If redirected connection fail, also abort the gateway connection.  Return the error of the redirected connection.
4. Rename option enabled to enableRedirect