### PR TITLE
fix for 1.0.2 crash due to persistent wrong usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # PHP mysqlnd redirection extension mysqlnd_azure
 The source code here is a PHP extension implemented using mysqlnd plugin API (https://www.php.net/manual/en/mysqlnd.plugin.php), which provides redirection feature support.  The extension is also available on PECL website at  https://pecl.php.net/package/mysqlnd_azure.
 
+**Important notice: There is a limitation that for Azure MySQL, redirection is only possible when the connection is configured with SSL.**
+
 ## Name and Extension Version
 Extension name: **mysqlnd_azure**
 
@@ -9,7 +11,8 @@ Required PHP min version: PHP7.2.15+ and PHP7.3.2+.
 Valid version:
 - 1.0.0  Change: initial version. Limitation: cannot install with pecl on linux; cannot work with 7.2.23+ and 7.3.10+
 - 1.0.1  Change: with pecl install command line support on linux. Limitation: cannot work with 7.2.23+ and 7.3.10+
-- 1.0.2  Change: fix compatibility problem with  7.2.23+ and 7.3.10+
+- 1.0.2  Change: fix compatibility problem with  7.2.23+ and 7.3.10+.  Limitation: crash when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false.
+- 1.0.2-hotfix Change: fix the crash problem when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false.
 
 Following is a brief guide of how to install using pecl or build and test the extension from source. 
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Required PHP min version: PHP7.2.15+ and PHP7.3.2+.
 Valid version:
 - 1.0.0  Change: initial version. Limitation: cannot install with pecl on linux; cannot work with 7.2.23+ and 7.3.10+
 - 1.0.1  Change: with pecl install command line support on linux. Limitation: cannot work with 7.2.23+ and 7.3.10+
-- 1.0.2  Change: fix compatibility problem with  7.2.23+ and 7.3.10+.  Limitation: crash when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false.
-- 1.0.2-hotfix Change: fix the crash problem when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false.
+- 1.0.2  Change: fix compatibility problem with  7.2.23+ and 7.3.10+.  Limitation: crash when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false
+- 1.0.2-hotfix Change: fix the crash problem when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false
 
 Following is a brief guide of how to install using pecl or build and test the extension from source. 
 

--- a/mysqlnd_azure.c
+++ b/mysqlnd_azure.c
@@ -59,7 +59,7 @@ mysqlnd_azure_get_is_using_redirect(const MYSQLND_CONN_DATA *conn)
 	MYSQLND_AZURE_CONN_DATA** props = NULL;
 	props = (MYSQLND_AZURE_CONN_DATA**)mysqlnd_plugin_get_plugin_connection_data_data(conn, mysqlnd_azure_plugin_id);
 	if (!props || !(*props)) {
-		*props = mnd_pecalloc(1, sizeof(MYSQLND_AZURE_CONN_DATA), conn->persistent);
+		*props = mnd_pemalloc(sizeof(MYSQLND_AZURE_CONN_DATA), conn->persistent);
         if(!props  || !(*props)) {
             return NULL;
         }
@@ -76,7 +76,7 @@ mysqlnd_azure_set_is_using_redirect(MYSQLND_CONN_DATA *conn, zend_bool is_using_
 	MYSQLND_AZURE_CONN_DATA** props = NULL;
 	props = (MYSQLND_AZURE_CONN_DATA**)mysqlnd_plugin_get_plugin_connection_data_data(conn, mysqlnd_azure_plugin_id);
 	if (!props || !(*props)) {
-		*props = mnd_pecalloc(1, sizeof(MYSQLND_AZURE_CONN_DATA), conn->persistent);
+		*props = mnd_pemalloc(sizeof(MYSQLND_AZURE_CONN_DATA), conn->persistent);
         if(!props  || !(*props)) {
             return NULL;
         }

--- a/mysqlnd_azure.c
+++ b/mysqlnd_azure.c
@@ -222,7 +222,7 @@ get_redirect_info(const MYSQLND_CONN_DATA * const conn, char* redirect_host, cha
     const char * msg_header = "Location: mysql://";
     int msg_header_len = strlen(msg_header);
 
-    if (conn->last_message.l <= 27 || (strncmp(conn->last_message.s, msg_header, msg_header_len) != 0)) {
+    if (conn->last_message.l < 28 || (strncmp(conn->last_message.s, msg_header, msg_header_len) != 0)) {
         return FALSE;
     }
 

--- a/mysqlnd_azure.c
+++ b/mysqlnd_azure.c
@@ -174,6 +174,77 @@ copyFailed:
 }
 /* }}} */
 
+/* {{{ get_redirect_info */
+static zend_bool
+get_redirect_info(const MYSQLND_CONN_DATA * const conn, char* redirect_host, char* redirect_user, unsigned int* p_ui_redirect_port)
+{
+	/**
+	* Get redirected server information contained in OK packet.
+	* Redirection string has following format:
+	* Location: mysql://redirectedHostName:redirectedPort/user=redirectedUser
+	* the minimal len is 28 bytes
+	*/
+
+    const char * msg_header = "Location: mysql://";
+    int msg_header_len = strlen(msg_header);
+
+    if (conn->last_message.l <= 27 || (strncmp(conn->last_message.s, msg_header, msg_header_len) != 0)) {
+        return FALSE;
+    }
+
+    char *cur_pos = conn->last_message.s + msg_header_len;
+    char *end = conn->last_message.s + conn->last_message.l;
+
+    char* host_begin = cur_pos, *host_end = NULL, *port_begin = NULL, *port_end = NULL, *user_begin = NULL,  *user_end = NULL;
+    zend_bool found_host = FALSE, found_port = FALSE, found_user = FALSE;
+
+    while(cur_pos < end) {
+        if(found_host == FALSE && *cur_pos == ':') {
+            host_end = cur_pos;
+            cur_pos++;
+            port_begin = cur_pos;
+            found_host = TRUE;
+        }
+
+        if(found_host == TRUE && found_port == FALSE && *cur_pos == '/') {
+            port_end = cur_pos;
+            found_port = TRUE;
+
+            cur_pos++;
+            int user_delimiter_len = strlen("user=");
+            if(end - cur_pos > user_delimiter_len && strncmp(cur_pos, "user=", user_delimiter_len)==0) {
+                user_begin = cur_pos + user_delimiter_len;
+                user_end = end;
+                found_user = TRUE;
+                break;
+            }
+        }
+
+        cur_pos++;
+    }
+
+    if(!found_host || !found_port || !found_user) {
+        return FALSE;
+    }
+
+    int host_len = host_end - host_begin;
+    int port_len = port_end - port_begin;
+    int user_len = user_end - user_begin;
+
+    if(host_len<=0 || port_len<=0 || user_len<=0 || host_len > MAX_REDIRECT_HOST_LEN || port_len > 8 || user_len > MAX_REDIRECT_USER_LEN) {
+        return FALSE;
+    }
+
+    char  redirect_port[8] = { 0 };
+
+    memcpy(redirect_host, host_begin, host_len);
+    memcpy(redirect_user, user_begin, user_len);
+    memcpy(redirect_port, port_begin, port_len);
+    *p_ui_redirect_port = atoi(redirect_port);
+
+    return TRUE;
+}
+
 /* {{{ mysqlnd_azure_data::connect */
 MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
 						MYSQLND_CSTRING hostname,
@@ -277,111 +348,114 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
 	{
 		SET_CONNECTION_STATE(&conn->state, CONN_READY); //set ready status so the connection can be closed correctly later if redirect succeeds
 
+		DBG_ENTER("[redirect]: mysqlnd_azure_data::connect::redirect");
+		char redirect_host[MAX_REDIRECT_HOST_LEN] = { 0 };
+		char redirect_user[MAX_REDIRECT_USER_LEN] = { 0 };
+		unsigned int ui_redirect_port = 0;
+		zend_bool serverSupportRedirect = get_redirect_info(conn, redirect_host, redirect_user, &ui_redirect_port);
+		if (!serverSupportRedirect) {
+			//do nothing else for redirection, just use the previous connection
+			DBG_ENTER("[redirect]: Server doesnot supoort redirection, do not need redirection. ");
+			goto after_conn;
+		}
+
+		//Get here means serverSupportRedirect
 		MYSQLND_AZURE_CONN_DATA** pdata = mysqlnd_azure_get_is_using_redirect(conn);
+        if(pdata==NULL) {
+			//mysqlnd_azure_get_is_using_redirect failed due to oom, do nothing here, just keep go with original connection if still usable.
+			goto after_conn;
+        }
 
-		if (!(*pdata)->is_using_redirect && conn->last_message.l > 27 && (strncmp((char*)conn->last_message.s, "Location:", strlen("Location:")) == 0) && ((strstr((char*)conn->last_message.s, "mysql://")) != NULL)) { //there is a redirection connection info we can take use of
-			/**
-			* Get redirected server information contained in OK packet.
-			* Redirection string somehow look like:
-			* Location: mysql://redirectedHostName:redirectedPort/user=redirectedUser
-			* the minimal len is 27 bytes
-			*/
-			DBG_ENTER("[redirect] mysqlnd_azure_data::connect::redirect");
-			char redirect_host[MAX_REDIRECT_HOST_LEN] = { 0 };
-			char redirect_user[MAX_REDIRECT_USER_LEN] = { 0 };
-			unsigned int ui_redirect_port = 0;
-			char  redirect_port[8] = { 0 };
+		//Already use redirected connection, or the connection string is a redirected one
+		if ((*pdata)->is_using_redirect || (strcmp(redirect_host, hostname.s) == 0 && strcmp(redirect_user, username.s) == 0 && ui_redirect_port == port)) {
+			DBG_ENTER("[redirect]: Is using redirection, or redirection info are equal to origin, no need to redirect");
+			goto after_conn;
+		}
 
-			int redirect_total_len = conn->last_message.l;
-			unsigned char *cur_pos = conn->last_message.s;
-			char *p1 = strstr((char*)cur_pos, "//");
-			char *p2 = strstr(p1, ":");
-			char *p3 = strstr((char*)cur_pos, "user=");
+		//serverSupportRedirect, and currently used conn is not redirected connection, start redirection handshake
+		{
+			DBG_INF_FMT("[redirect]: redirect host=%s user=%s port=%d ", redirect_host, redirect_user, ui_redirect_port);
+			enum_func_status ret = FAIL;
+			MYSQLND* redirect_conneHandle = mysqlnd_init(MYSQLND_CLIENT_KNOWS_RSET_COPY_DATA, conn->persistent); //init MYSQLND but only need only MYSQLND_CONN_DATA here
+			MYSQLND_CONN_DATA* redirect_conn = redirect_conneHandle->data;
+			redirect_conneHandle->data = NULL;
+			mnd_pefree(redirect_conneHandle, redirect_conneHandle->persistent);
+			redirect_conneHandle = NULL;
 
-			int redirect_host_len = p2 - p1 - 2;
-			int redirect_port_len = p3 - p2 - 2;
-			int redirect_user_len = redirect_total_len - (p3 + 5 - ((char*)cur_pos));
-			if (redirect_host_len <= 0 || redirect_port_len <= 0 || redirect_user_len <= 0) {
-				redirect_host_len = redirect_port_len = redirect_user_len = 0;
-			}
-			else {
-				memcpy(redirect_host, p1 + 2, redirect_host_len);
-				memcpy(redirect_user, p3 + 5, redirect_user_len);
-				memcpy(redirect_port, p2 + 1, redirect_port_len);
-				ui_redirect_port = atoi(redirect_port);
+			ret = set_redirect_client_options(conn, redirect_conn);
+
+			//init redirect_conn options failed, just use the proxy connection
+			if (ret == FAIL) {
+				//release resource
+				redirect_conn->m->dtor(redirect_conn);
+				goto after_conn;
 			}
 
-			if (redirect_host_len > 0 && redirect_user_len > 0 && redirect_port_len > 0
-				&& (strcmp(redirect_host, hostname.s) || strcmp(redirect_user, username.s) || ui_redirect_port != port)) { //currently used conn is not redirected connection
-				enum_func_status ret = FAIL;
-				MYSQLND* redirect_conneHandle = mysqlnd_init(MYSQLND_CLIENT_KNOWS_RSET_COPY_DATA, conn->persistent); //init MYSQLND but only need only MYSQLND_CONN_DATA here
-				MYSQLND_CONN_DATA* redirect_conn = redirect_conneHandle->data;
-				redirect_conneHandle->data = NULL;
-				mnd_pefree(redirect_conneHandle, redirect_conneHandle->persistent);
-				redirect_conneHandle = NULL;
-				
-				DBG_INF_FMT("[redirect]: redirect host=%s user=%s port=%s ", redirect_host, redirect_user, redirect_port);
+			//init redirect_conn succeeded, use this conn to start a new connection and handshake
 
-				ret = set_redirect_client_options(conn, redirect_conn);
-				if (ret == FAIL) { //init redirect_conn failed
-					redirect_conn->m->dtor(redirect_conn);
-					DBG_ENTER("[redirect]: mysql redirect fails to copy MYSQLND_CONN_DATA, use original connection information!");
+            //set is_using_redirect flag
+			MYSQLND_AZURE_CONN_DATA** data_ret = mysqlnd_azure_set_is_using_redirect(redirect_conn, 1);
+            if(data_ret==NULL) {
+                //mysqlnd_azure_set_is_using_redirect failed due to oom, do nothing here, just keep go with original connection if still usable.
+                redirect_conn->m->dtor(redirect_conn);
+                goto after_conn;
+            }
+
+			const MYSQLND_CSTRING redirect_hostname = { redirect_host, strlen(redirect_host) };
+			const MYSQLND_CSTRING redirect_username = { redirect_user, strlen(redirect_user) };
+			MYSQLND_STRING redirect_transport = redirect_conn->m->get_scheme(redirect_conn, redirect_hostname, &socket_or_pipe, ui_redirect_port, &unix_socket, &named_pipe);
+
+			const MYSQLND_CSTRING redirect_scheme = { redirect_transport.s, redirect_transport.l };
+
+			enum_func_status redirectState = redirect_conn->m->connect_handshake(redirect_conn, &redirect_scheme, &redirect_username, &password, &database, mysql_flags);
+
+			if (redirectState == PASS) { //handshake with redirect_conn succeeded, replace original connection info with redirect_conn and add the redirect info into cache table
+
+				//add the redirect info into cache table
+				mysqlnd_azure_add_redirect_cache(username.s, hostname.s, port, redirect_username.s, redirect_hostname.s, ui_redirect_port);
+
+				//close previous proxy connection
+				conn->m->send_close(conn);
+				conn->m->dtor(conn);
+				if (transport.s) {
+					mnd_sprintf_free(transport.s);
+					transport.s = NULL;
 				}
-				else { //init redirect_conn succeeded, use this conn to start a new connection and handshake
-					MYSQLND_CSTRING redirect_hostname = { redirect_host, strlen(redirect_host) };
-					MYSQLND_CSTRING redirect_username = { redirect_user, strlen(redirect_user) };
-					MYSQLND_STRING redirect_transport = redirect_conn->m->get_scheme(redirect_conn, redirect_hostname, &socket_or_pipe, ui_redirect_port, &unix_socket, &named_pipe);
-					const MYSQLND_CSTRING redirect_scheme = { redirect_transport.s, redirect_transport.l };
 
-					mysqlnd_azure_set_is_using_redirect(redirect_conn, 1);
+				//upate conn, pfc,  pconn for later user
+				conn = redirect_conn;
+				pfc = redirect_conn->protocol_frame_codec; //this variable will be used in after_conn context, so need take care
+				*pconn = redirect_conn; //use new conn outside for caller
 
-					enum_func_status redirectState = redirect_conn->m->connect_handshake(redirect_conn, &redirect_scheme, &redirect_username, &password, &database, mysql_flags);
+				//upate host, user, transport for later user
+				hostname = redirect_hostname;
+				username = redirect_username;
+				port = ui_redirect_port;
+				transport = redirect_transport;
 
-					if (redirectState == FAIL) { //handshake with new redirection MYSQLND_CONN_DATA failed, release resource and use original connection
-						redirect_conn->m->dtor(redirect_conn);
-						if (redirect_transport.s) {
-							mnd_sprintf_free(redirect_transport.s);
-							redirect_transport.s = NULL;
-						}
-						DBG_ENTER("[redirect]: mysql redirect handshake fails, use original connection information!");
-					}
-					else { //handshake with redirect_conn succeeded, close and release resource of original conn and replace it with redirect_conn
+				DBG_ENTER("[redirect]: mysql redirect handshake succeeded.");
 
-						//add the redirect info into cache table
-						mysqlnd_azure_add_redirect_cache(conn, username.s, hostname.s, port, redirect_username.s, redirect_hostname.s, ui_redirect_port);
-
-						conn->m->send_close(conn);
-						conn->m->dtor(conn);
-						pfc = NULL;
-						//upate conn, transport,  pconn for later user
-						conn = redirect_conn;
-						if (transport.s) {
-							mnd_sprintf_free(transport.s);
-							transport.s = NULL;
-						}
-						transport = redirect_transport;
-						*pconn = redirect_conn; //use new conn outside for caller
-
-						///upate host, user, pfc for later user
-						hostname = redirect_hostname;
-						username = redirect_username;
-						port = ui_redirect_port;
-						pfc = redirect_conn->protocol_frame_codec;
-
-						DBG_ENTER("[redirect]: mysql redirect handshake succeeded.");
-					}
-				}
 			}
-			else {
-				DBG_ENTER("[redirect]: redirection info are equal to origin, no need to redirect");
+			else { //redirect failed. use original connection information
+
+				//clear is_using_redirect flag. This step is not need explictly, since object redirect_conn will be destroyed
+				//MYSQLND_AZURE_CONN_DATA** data_ret = mysqlnd_azure_set_is_using_redirect(redirect_conn, 0);
+
+				//free resource, and use original connection information
+				redirect_conn->m->dtor(redirect_conn);
+				if (redirect_transport.s) {
+					mnd_sprintf_free(redirect_transport.s);
+					redirect_transport.s = NULL;
+				}
+				DBG_ENTER("[redirect]: mysql redirect handshake fails, use original connection information!");
+
 			}
 		}
-		else {
-			DBG_ENTER("[redirect]: already use redirection info or can not find redirection location in ok packet");
-		}
+
 	}
 	/*end of Azure Redirection Logic*/
 
+after_conn:
 	{
 		SET_CONNECTION_STATE(&conn->state, CONN_READY);
 
@@ -534,35 +608,56 @@ MYSQLND_METHOD(mysqlnd_azure, connect)(MYSQLND * conn_handle,
 			mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_server_host", hostname.s);
 		}
 
-		if(!MYSQLND_AZURE_G(enabled)) {
+		if (!MYSQLND_AZURE_G(enabled)) {
 			DBG_ENTER("mysqlnd_azure::connect redirect disabled");
 			ret = org_conn_d_m.connect(*pconn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);
 		}
 		else {
 			DBG_ENTER("mysqlnd_azure::connect redirect enabled");
 
-			//first check whether the redirect info already cached
-			MYSQLND_AZURE_REDIRECT_INFO* redirect_info = mysqlnd_azure_find_redirect_cache(*pconn, username.s, hostname.s, port);
-			if (redirect_info != NULL) {
-				DBG_ENTER("mysqlnd_azure::connect try the cached info first");
-				MYSQLND_CSTRING redirect_host = { redirect_info->redirect_host, strlen(redirect_info->redirect_host) };
-				MYSQLND_CSTRING redirect_user = { redirect_info->redirect_user, strlen(redirect_info->redirect_user) };
+			//Redirection is only possible with SSL at present. Continue with no redirection if SSL is not set
+			unsigned int temp_flags = (*pconn)->m->get_updated_connect_flags(*pconn, mysql_flags);
+			if (!(temp_flags & CLIENT_SSL)) {
+				ret = org_conn_d_m.connect(*pconn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);
+			}
+			else { //SSL is enabled
 
-				mysqlnd_azure_set_is_using_redirect(*pconn, 1);
-				ret = (*pconn)->m->connect(pconn, redirect_host, redirect_user, password, database, redirect_info->redirect_port, socket_or_pipe, mysql_flags);
-				if (ret == FAIL) {
-					//remove invalid cache
-					mysqlnd_azure_remove_redirect_cache(*pconn, username.s, hostname.s, port);
+				//first check whether the redirect info already cached
+				MYSQLND_AZURE_REDIRECT_INFO* redirect_info = mysqlnd_azure_find_redirect_cache(username.s, hostname.s, port);
+				if (redirect_info != NULL) {
+					DBG_ENTER("mysqlnd_azure::connect try the cached info first");
+					const MYSQLND_CSTRING redirect_host = { redirect_info->redirect_host, strlen(redirect_info->redirect_host) };
+					const MYSQLND_CSTRING redirect_user = { redirect_info->redirect_user, strlen(redirect_info->redirect_user) };
 
-					mysqlnd_azure_set_is_using_redirect(*pconn, 0);
+					MYSQLND_AZURE_CONN_DATA** data_ret = mysqlnd_azure_set_is_using_redirect(*pconn, 1);
+                    if(data_ret==NULL) {
+                        SET_OOM_ERROR((*pconn)->error_info);
+                        return FAIL;
+                    }
+
+					ret = (*pconn)->m->connect(pconn, redirect_host, redirect_user, password, database, redirect_info->redirect_port, socket_or_pipe, mysql_flags);
+					if (ret == FAIL) {
+						//remove invalid cache
+						mysqlnd_azure_remove_redirect_cache(username.s, hostname.s, port);
+
+						MYSQLND_AZURE_CONN_DATA** data_ret = mysqlnd_azure_set_is_using_redirect(*pconn, 0);
+                        if(data_ret==NULL) {
+                            SET_OOM_ERROR((*pconn)->error_info);
+                            return FAIL;
+                        }
+
+						ret = (*pconn)->m->connect(pconn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);
+					}
+				}
+				else {
 					ret = (*pconn)->m->connect(pconn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);
 				}
-			}
-			else {
-				ret = (*pconn)->m->connect(pconn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);
+
 			}
 		}
+
 		(*pconn)->m->local_tx_end(*pconn, this_func, FAIL);
+
 	}
 	DBG_RETURN(ret);
 }
@@ -573,14 +668,12 @@ MYSQLND_METHOD(mysqlnd_azure, connect)(MYSQLND * conn_handle,
 void mysqlnd_azure_minit_register_hooks()
 {
 	mysqlnd_azure_plugin_id = mysqlnd_plugin_register();
-	
+
 	conn_m = mysqlnd_conn_get_methods();
-	memcpy(&org_conn_m, conn_m,
-	sizeof(struct st_mysqlnd_conn_methods));
-	
+	memcpy(&org_conn_m, conn_m, sizeof(struct st_mysqlnd_conn_methods));
+
 	conn_d_m = mysqlnd_conn_data_get_methods();
-	memcpy(&org_conn_d_m, conn_d_m,
-	sizeof(struct st_mysqlnd_conn_data_methods));
+	memcpy(&org_conn_d_m, conn_d_m, sizeof(struct st_mysqlnd_conn_data_methods));
 
 	conn_m->connect = MYSQLND_METHOD(mysqlnd_azure, connect);
 	conn_d_m->connect = MYSQLND_METHOD(mysqlnd_azure_data, connect);

--- a/mysqlnd_azure.c
+++ b/mysqlnd_azure.c
@@ -18,7 +18,7 @@
 
 
 #ifdef HAVE_CONFIG_H
-# include "config.h"
+#include "config.h"
 #endif
 
 #include "php_mysqlnd_azure.h"

--- a/mysqlnd_azure.h
+++ b/mysqlnd_azure.h
@@ -41,7 +41,6 @@ typedef struct st_mysqlnd_azure_redirect_info {
 #define MAX_REDIRECT_HOST_LEN 128
 #define MAX_REDIRECT_USER_LEN 128
 
-extern unsigned int mysqlnd_azure_plugin_id;
 void mysqlnd_azure_minit_register_hooks();
 
 MYSQLND_AZURE_CONN_DATA** mysqlnd_azure_get_is_using_redirect(const MYSQLND_CONN_DATA *conn);

--- a/mysqlnd_azure.h
+++ b/mysqlnd_azure.h
@@ -46,9 +46,9 @@ void mysqlnd_azure_minit_register_hooks();
 
 MYSQLND_AZURE_CONN_DATA** mysqlnd_azure_get_is_using_redirect(const MYSQLND_CONN_DATA *conn);
 MYSQLND_AZURE_CONN_DATA** mysqlnd_azure_set_is_using_redirect(MYSQLND_CONN_DATA *conn, zend_bool is_using_redirect);
-enum_func_status mysqlnd_azure_add_redirect_cache(const MYSQLND_CONN_DATA* conn, const char* user, const char* host, int port, const char* redirect_user, const char* redirect_host, int redirect_port);
-enum_func_status mysqlnd_azure_remove_redirect_cache(const MYSQLND_CONN_DATA* conn, const char* user, const char* host, int port);
-MYSQLND_AZURE_REDIRECT_INFO* mysqlnd_azure_find_redirect_cache(const MYSQLND_CONN_DATA* conn, const char* user, const char* host, int port);
+enum_func_status mysqlnd_azure_add_redirect_cache(const char* user, const char* host, int port, const char* redirect_user, const char* redirect_host, int redirect_port);
+enum_func_status mysqlnd_azure_remove_redirect_cache(const char* user, const char* host, int port);
+MYSQLND_AZURE_REDIRECT_INFO* mysqlnd_azure_find_redirect_cache(const char* user, const char* host, int port);
 
 #if defined(ZTS) && defined(COMPILE_DL_MYSQLND_AZURE)
 ZEND_TSRMLS_CACHE_EXTERN()

--- a/package.xml
+++ b/package.xml
@@ -16,8 +16,8 @@
   <email>Qianqian.Bu@microsoft.com</email>
   <active>yes</active>
  </lead>
- <date>2020-1-13</date>
- <time>16:00:13</time>
+ <date>2020-1-16</date>
+ <time>17:00:13</time>
  <version>
   <release>1.0.2-hotfix</release>
   <api>1.0.2-hotfix</api>
@@ -74,7 +74,7 @@
       <release>beta</release>
       <api>beta</api>
      </stability>
-     <date>2020-1-13</date>
+     <date>2020-1-16</date>
      <license uri="http://www.php.net/license">PHP License</license>
      <notes>
 apply fix for the crash problem when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false.

--- a/package.xml
+++ b/package.xml
@@ -16,19 +16,19 @@
   <email>Qianqian.Bu@microsoft.com</email>
   <active>yes</active>
  </lead>
- <date>2019-11-20</date>
- <time>13:00:13</time>
+ <date>2020-1-13</date>
+ <time>16:00:13</time>
  <version>
-  <release>1.0.2</release>
-  <api>1.0.2</api>
+  <release>1.0.2-hotfix</release>
+  <api>1.0.2-hotfix</api>
  </version>
  <stability>
-  <release>stable</release>
-  <api>stable</api>
+  <release>beta</release>
+  <api>beta</api>
  </stability>
  <license uri="http://www.php.net/license">PHP License</license>
  <notes>
-- apply fix for database null/empty problem change in https://github.com/php/php-src/pull/4340 in MYSQLND_METHOD(mysqlnd_conn_data, connect) to MYSQLND_METHOD(mysqlnd_azure_data, connect)
+- apply fix for the crash problem when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false.
  </notes>
  <contents>
   <dir name="/">
@@ -65,6 +65,21 @@
  <providesextension>mysqlnd_azure</providesextension>
  <extsrcrelease />
  <changelog>
+    <release>
+     <version>
+     <release>1.0.2-hotfix</release>
+     <api>1.0.2-hotfix</api>
+     </version>
+     <stability>
+      <release>beta</release>
+      <api>beta</api>
+     </stability>
+     <date>2020-1-13</date>
+     <license uri="http://www.php.net/license">PHP License</license>
+     <notes>
+apply fix for the crash problem when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false.
+     </notes>
+   </release>
    <release>
     <version>
     <release>1.0.2</release>

--- a/php_mysqlnd_azure.c
+++ b/php_mysqlnd_azure.c
@@ -17,7 +17,7 @@
 */
 
 #ifdef HAVE_CONFIG_H
-# include "config.h"
+#include "config.h"
 #endif
 
 #include "php.h"

--- a/php_mysqlnd_azure.c
+++ b/php_mysqlnd_azure.c
@@ -21,10 +21,10 @@
 #endif
 
 #include "php.h"
-#include "ext/standard/info.h"
 #include "mysqlnd_azure.h"
 #include "php_mysqlnd_azure.h"
 #include "ext/mysqlnd/mysqlnd_ext_plugin.h"
+#include "ext/standard/info.h"
 
 ZEND_DECLARE_MODULE_GLOBALS(mysqlnd_azure)
 

--- a/php_mysqlnd_azure.h
+++ b/php_mysqlnd_azure.h
@@ -29,7 +29,7 @@ extern zend_module_entry mysqlnd_azure_module_entry;
 # define phpext_mysqlnd_azure_ptr &mysqlnd_azure_module_entry
 
 #define EXT_MYSQLND_AZURE_NAME      "mysqlnd_azure"
-#define EXT_MYSQLND_AZURE_VERSION   "1.0.2"
+#define EXT_MYSQLND_AZURE_VERSION   "1.0.2-hotfix"
 
 ZEND_BEGIN_MODULE_GLOBALS(mysqlnd_azure)
 	zend_bool		enabled;

--- a/php_mysqlnd_azure.h
+++ b/php_mysqlnd_azure.h
@@ -17,7 +17,7 @@
 */
 
 #ifndef PHP_MYSQLND_AZURE_H
-# define PHP_MYSQLND_AZURE_H
+#define PHP_MYSQLND_AZURE_H
 
 #ifdef HAVE_CONFIG_H
 #include "config.h"
@@ -26,7 +26,7 @@
 #include "php.h"
 
 extern zend_module_entry mysqlnd_azure_module_entry;
-# define phpext_mysqlnd_azure_ptr &mysqlnd_azure_module_entry
+#define phpext_mysqlnd_azure_ptr &mysqlnd_azure_module_entry
 
 #define EXT_MYSQLND_AZURE_NAME      "mysqlnd_azure"
 #define EXT_MYSQLND_AZURE_VERSION   "1.0.2-hotfix"

--- a/redirect_cache.c
+++ b/redirect_cache.c
@@ -34,55 +34,22 @@ static void mysqlnd_azure_redirect_info_dtor(zval *zv)
 {
 	MYSQLND_AZURE_REDIRECT_INFO *redirect_info = (MYSQLND_AZURE_REDIRECT_INFO*)Z_PTR_P(zv);
 
-    if (redirect_info==NULL) {
-        return;
-    }
+    if (redirect_info != NULL) {
 
-	if (redirect_info->redirect_user) {
-		mnd_pefree(redirect_info->redirect_user, 1);
-		redirect_info->redirect_user = NULL;
-	}
-	if (redirect_info->redirect_host) {
-		mnd_pefree(redirect_info->redirect_host, 1);
-		redirect_info->redirect_host = NULL;
-	}
-	if (redirect_info) {
+        if (redirect_info->redirect_user) {
+            mnd_pefree(redirect_info->redirect_user, 1);
+            redirect_info->redirect_user = NULL;
+        }
+        if (redirect_info->redirect_host) {
+            mnd_pefree(redirect_info->redirect_host, 1);
+            redirect_info->redirect_host = NULL;
+        }
+
 		mnd_pefree(redirect_info, 1);
 		redirect_info = NULL;
-	}
-}
-/* }}} */
+      
+    }
 
-/* {{{ mysqlnd_azure_get_is_using_redirect */
-MYSQLND_AZURE_CONN_DATA** mysqlnd_azure_get_is_using_redirect(const MYSQLND_CONN_DATA *conn)
-{
-	MYSQLND_AZURE_CONN_DATA** props;
-	props = (MYSQLND_AZURE_CONN_DATA**)mysqlnd_plugin_get_plugin_connection_data_data(conn, mysqlnd_azure_plugin_id);
-	if (!props || !(*props)) {
-		*props = mnd_pecalloc(1, sizeof(MYSQLND_AZURE_CONN_DATA), conn->persistent);
-        if(!props  || !(*props)) {
-            return NULL;
-        }
-		(*props)->is_using_redirect = 0;
-	}
-	return props;
-}
-/* }}} */
-
-/* {{{ mysqlnd_azure_set_is_using_redirect */
-MYSQLND_AZURE_CONN_DATA** mysqlnd_azure_set_is_using_redirect(MYSQLND_CONN_DATA *conn, zend_bool is_using_redirect)
-{
-	MYSQLND_AZURE_CONN_DATA** props;
-	props = (MYSQLND_AZURE_CONN_DATA**)mysqlnd_plugin_get_plugin_connection_data_data(conn, mysqlnd_azure_plugin_id);
-	if (!props || !(*props)) {
-		*props = mnd_pecalloc(1, sizeof(MYSQLND_AZURE_CONN_DATA), conn->persistent);
-        if(!props  || !(*props)) {
-            return NULL;
-        }
-		(*props)->is_using_redirect = 0;
-	}
-	(*props)->is_using_redirect = is_using_redirect;
-	return props;
 }
 /* }}} */
 
@@ -104,8 +71,14 @@ enum_func_status mysqlnd_azure_add_redirect_cache(const char* user, const char* 
     }
 
 	MYSQLND_AZURE_REDIRECT_INFO* redirect_info = pemalloc(sizeof(MYSQLND_AZURE_REDIRECT_INFO), 1);
+    if(redirect_info == NULL) {
+        return FAIL;
+    }
 	redirect_info->redirect_user = mnd_pestrndup(redirect_user, strlen(redirect_user), 1);
 	redirect_info->redirect_host = mnd_pestrndup(redirect_host, strlen(redirect_host), 1);
+    if(redirect_info->redirect_user == NULL || redirect_info->redirect_host == NULL) {
+        return FAIL;
+    }
 	redirect_info->redirect_port = redirect_port;
 
 	zend_hash_str_update_ptr(MYSQLND_AZURE_G(redirectCache), key, strlen(key), redirect_info);
@@ -119,17 +92,16 @@ enum_func_status mysqlnd_azure_add_redirect_cache(const char* user, const char* 
 /* {{{ mysqlnd_azure_remove_redirect_cache */
 enum_func_status mysqlnd_azure_remove_redirect_cache(const char* user, const char* host, int port)
 {
-	if (MYSQLND_AZURE_G(redirectCache) == NULL)
-		return PASS;
+	if (MYSQLND_AZURE_G(redirectCache) != NULL) {
+        char *key = NULL;
+        mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN + MAX_REDIRECT_USER_LEN + 8, "%s_%s_%d", user, host, port);
+        if(!key) {
+            return FAIL;
+        }
+        zend_hash_str_del(MYSQLND_AZURE_G(redirectCache), key, strlen(key));
 
-	char *key = NULL;
-	mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN + MAX_REDIRECT_USER_LEN + 8, "%s_%s_%d", user, host, port);
-    if(!key) {
-        return FAIL;
+        mnd_sprintf_free(key);
     }
-	zend_hash_str_del(MYSQLND_AZURE_G(redirectCache), key, strlen(key));
-
-	mnd_sprintf_free(key);
 
 	return PASS;
 }
@@ -138,18 +110,19 @@ enum_func_status mysqlnd_azure_remove_redirect_cache(const char* user, const cha
 /* {{{ mysqlnd_azure_find_redirect_cache */
 MYSQLND_AZURE_REDIRECT_INFO* mysqlnd_azure_find_redirect_cache(const char* user, const char* host, int port)
 {
-	if (MYSQLND_AZURE_G(redirectCache) == NULL)
-		return NULL;
+	if (MYSQLND_AZURE_G(redirectCache) != NULL) {
+        char *key = NULL;
+        mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN + MAX_REDIRECT_USER_LEN + 8, "%s_%s_%d", user, host, port);
+        if(!key) {
+            return NULL;
+        }
 
-	char *key = NULL;
-	mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN + MAX_REDIRECT_USER_LEN + 8, "%s_%s_%d", user, host, port);
-    if(!key) {
-        return FAIL;
+        void* zv_dest = zend_hash_str_find_ptr(MYSQLND_AZURE_G(redirectCache), key, strlen(key));
+        mnd_sprintf_free(key);
+
+        return (MYSQLND_AZURE_REDIRECT_INFO*)zv_dest;
     }
 
-	void* zv_dest = zend_hash_str_find_ptr(MYSQLND_AZURE_G(redirectCache), key, strlen(key));
-	mnd_sprintf_free(key);
-
-	return (MYSQLND_AZURE_REDIRECT_INFO*)zv_dest;
+    return NULL;
 }
 /* }}} */

--- a/redirect_cache.c
+++ b/redirect_cache.c
@@ -86,9 +86,9 @@ enum_func_status mysqlnd_azure_add_redirect_cache(const MYSQLND_CONN_DATA* conn,
 	char *key = NULL;
 	mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN+ MAX_REDIRECT_USER_LEN+8, "%s_%s_%d", user, host, port);
 
-	MYSQLND_AZURE_REDIRECT_INFO* redirect_info = pemalloc(sizeof(MYSQLND_AZURE_REDIRECT_INFO), conn->persistent);
-	redirect_info->redirect_user = mnd_pestrndup(redirect_user, strlen(redirect_user), conn->persistent);
-	redirect_info->redirect_host = mnd_pestrndup(redirect_host, strlen(redirect_host), conn->persistent);
+	MYSQLND_AZURE_REDIRECT_INFO* redirect_info = pemalloc(sizeof(MYSQLND_AZURE_REDIRECT_INFO), 1);
+	redirect_info->redirect_user = mnd_pestrndup(redirect_user, strlen(redirect_user), 1);
+	redirect_info->redirect_host = mnd_pestrndup(redirect_host, strlen(redirect_host), 1);
 	redirect_info->redirect_port = redirect_port;
 
 	zend_hash_str_update_ptr(MYSQLND_AZURE_G(redirectCache), key, strlen(key), redirect_info);

--- a/redirect_cache.c
+++ b/redirect_cache.c
@@ -18,7 +18,7 @@
 
 
 #ifdef HAVE_CONFIG_H
-# include "config.h"
+#include "config.h"
 #endif
 
 #include "php_mysqlnd_azure.h"

--- a/redirect_cache.c
+++ b/redirect_cache.c
@@ -33,6 +33,11 @@
 static void mysqlnd_azure_redirect_info_dtor(zval *zv)
 {
 	MYSQLND_AZURE_REDIRECT_INFO *redirect_info = (MYSQLND_AZURE_REDIRECT_INFO*)Z_PTR_P(zv);
+
+    if (redirect_info==NULL) {
+        return;
+    }
+
 	if (redirect_info->redirect_user) {
 		mnd_pefree(redirect_info->redirect_user, 1);
 		redirect_info->redirect_user = NULL;
@@ -55,6 +60,9 @@ MYSQLND_AZURE_CONN_DATA** mysqlnd_azure_get_is_using_redirect(const MYSQLND_CONN
 	props = (MYSQLND_AZURE_CONN_DATA**)mysqlnd_plugin_get_plugin_connection_data_data(conn, mysqlnd_azure_plugin_id);
 	if (!props || !(*props)) {
 		*props = mnd_pecalloc(1, sizeof(MYSQLND_AZURE_CONN_DATA), conn->persistent);
+        if(!props  || !(*props)) {
+            return NULL;
+        }
 		(*props)->is_using_redirect = 0;
 	}
 	return props;
@@ -68,6 +76,9 @@ MYSQLND_AZURE_CONN_DATA** mysqlnd_azure_set_is_using_redirect(MYSQLND_CONN_DATA 
 	props = (MYSQLND_AZURE_CONN_DATA**)mysqlnd_plugin_get_plugin_connection_data_data(conn, mysqlnd_azure_plugin_id);
 	if (!props || !(*props)) {
 		*props = mnd_pecalloc(1, sizeof(MYSQLND_AZURE_CONN_DATA), conn->persistent);
+        if(!props  || !(*props)) {
+            return NULL;
+        }
 		(*props)->is_using_redirect = 0;
 	}
 	(*props)->is_using_redirect = is_using_redirect;
@@ -76,15 +87,21 @@ MYSQLND_AZURE_CONN_DATA** mysqlnd_azure_set_is_using_redirect(MYSQLND_CONN_DATA 
 /* }}} */
 
 /* {{{ mysqlnd_azure_add_redirect_cache */
-enum_func_status mysqlnd_azure_add_redirect_cache(const MYSQLND_CONN_DATA* conn, const char* user, const char* host, int port, const char* redirect_user, const char* redirect_host, int redirect_port)
+enum_func_status mysqlnd_azure_add_redirect_cache(const char* user, const char* host, int port, const char* redirect_user, const char* redirect_host, int redirect_port)
 {
 	if (MYSQLND_AZURE_G(redirectCache) == NULL) {
 		MYSQLND_AZURE_G(redirectCache) = mnd_pemalloc(sizeof(HashTable), 1);
+        if(MYSQLND_AZURE_G(redirectCache) == NULL) {
+            return FAIL;
+        }
 		zend_hash_init(MYSQLND_AZURE_G(redirectCache), 0, NULL, mysqlnd_azure_redirect_info_dtor, 1);
 	}
 
-	char *key = NULL;
+	char* key = NULL;
 	mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN+ MAX_REDIRECT_USER_LEN+8, "%s_%s_%d", user, host, port);
+    if(!key) {
+        return FAIL;
+    }
 
 	MYSQLND_AZURE_REDIRECT_INFO* redirect_info = pemalloc(sizeof(MYSQLND_AZURE_REDIRECT_INFO), 1);
 	redirect_info->redirect_user = mnd_pestrndup(redirect_user, strlen(redirect_user), 1);
@@ -100,14 +117,16 @@ enum_func_status mysqlnd_azure_add_redirect_cache(const MYSQLND_CONN_DATA* conn,
 /* }}} */
 
 /* {{{ mysqlnd_azure_remove_redirect_cache */
-enum_func_status mysqlnd_azure_remove_redirect_cache(const MYSQLND_CONN_DATA* conn, const char* user, const char* host, int port)
+enum_func_status mysqlnd_azure_remove_redirect_cache(const char* user, const char* host, int port)
 {
 	if (MYSQLND_AZURE_G(redirectCache) == NULL)
 		return PASS;
 
 	char *key = NULL;
 	mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN + MAX_REDIRECT_USER_LEN + 8, "%s_%s_%d", user, host, port);
-
+    if(!key) {
+        return FAIL;
+    }
 	zend_hash_str_del(MYSQLND_AZURE_G(redirectCache), key, strlen(key));
 
 	mnd_sprintf_free(key);
@@ -117,13 +136,16 @@ enum_func_status mysqlnd_azure_remove_redirect_cache(const MYSQLND_CONN_DATA* co
 /* }}} */
 
 /* {{{ mysqlnd_azure_find_redirect_cache */
-MYSQLND_AZURE_REDIRECT_INFO* mysqlnd_azure_find_redirect_cache(const MYSQLND_CONN_DATA* conn, const char* user, const char* host, int port)
+MYSQLND_AZURE_REDIRECT_INFO* mysqlnd_azure_find_redirect_cache(const char* user, const char* host, int port)
 {
 	if (MYSQLND_AZURE_G(redirectCache) == NULL)
 		return NULL;
 
 	char *key = NULL;
 	mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN + MAX_REDIRECT_USER_LEN + 8, "%s_%s_%d", user, host, port);
+    if(!key) {
+        return FAIL;
+    }
 
 	void* zv_dest = zend_hash_str_find_ptr(MYSQLND_AZURE_G(redirectCache), key, strlen(key));
 	mnd_sprintf_free(key);

--- a/tests/mysqli_azure_redirection_disabled.phpt
+++ b/tests/mysqli_azure_redirection_disabled.phpt
@@ -33,6 +33,6 @@ echo "Done\n";
 ?>
 --EXPECTF--
 %s
-Location: mysql://tr%d.%s:%d/user=%s@%s
+Location: mysql://%s.%s:%d/user=%s@%s
 1
 Done

--- a/tests/mysqli_azure_redirection_enabled.phpt
+++ b/tests/mysqli_azure_redirection_enabled.phpt
@@ -32,7 +32,7 @@ mysqli_close($link);
 echo "Done\n";
 ?>
 --EXPECTF--
-tr%d.%s
-Location: mysql://tr%d.%s:%d/user=%s@%s
+%s.%s
+Location: mysql://%s.%s:%d/user=%s@%s
 0
 Done


### PR DESCRIPTION
When adding record to redirection cache hashtable, it also need to take care of the lifecycle of the string added, which should have same lifecycle with the hash table.  Otherwise, it will contains invalid memory type during the request shutdown and module shutdown process. 