### PR TITLE
Remove is using redirect flag and new test cases with embedded web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Valid version:
 - 1.0.2  Change: fix compatibility problem with  7.2.23+ and 7.3.10+.  Limitation: crash when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false
 - 1.0.3RC Change: fix the crash problem when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false.
                   This version is marked as beta, so please use *pecl install mysqlnd_azure-1.0.3RC* to install when using pecl.
-- 1.0.3  Change: Remove the use of is_using_redirect flag.
+- 1.0.3  Change: Remove the use of is_using_redirect flag. More strict validation and new test cases with embedded web server.
 
 Following is a brief guide of how to install using pecl or build and test the extension from source. 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Valid version:
 - 1.0.2  Change: fix compatibility problem with  7.2.23+ and 7.3.10+.  Limitation: crash when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false
 - 1.0.3RC Change: fix the crash problem when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false.
                   This version is marked as beta, so please use *pecl install mysqlnd_azure-1.0.3RC* to install when using pecl.
-- 1.0.3  Change: Remove the use of is_using_redirect flag. More strict validation and new test cases with embedded web server.
+- 1.0.3  Change: Remove the use of is_using_redirect flag. More strict validation and new test cases with php built-in web server.
 
 Following is a brief guide of how to install using pecl or build and test the extension from source. 
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Valid version:
 - 1.0.2  Change: fix compatibility problem with  7.2.23+ and 7.3.10+.  Limitation: crash when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false
 - 1.0.3RC Change: fix the crash problem when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false.
                   This version is marked as beta, so please use *pecl install mysqlnd_azure-1.0.3RC* to install when using pecl.
+- 1.0.3  Change: Remove the use of is_using_redirect flag.
 
 Following is a brief guide of how to install using pecl or build and test the extension from source. 
 

--- a/mysqlnd_azure.c
+++ b/mysqlnd_azure.c
@@ -2,7 +2,7 @@
   +----------------------------------------------------------------------+
   | PHP Version 7                                                        |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2006-2018 The PHP Group                                |
+  | Copyright (c) The PHP Group                                          |
   +----------------------------------------------------------------------+
   | This source file is subject to version 3.01 of the PHP license,      |
   | that is bundled with this package in the file LICENSE, and is        |

--- a/mysqlnd_azure.c
+++ b/mysqlnd_azure.c
@@ -35,57 +35,6 @@ struct st_mysqlnd_conn_data_methods* conn_d_m;
 struct st_mysqlnd_conn_methods org_conn_m;
 struct st_mysqlnd_conn_methods* conn_m;
 
-/* {{{ mysqlnd_conn_data::dtor */
-/*  to free the extra data is_using_redirect*/
-static void
-MYSQLND_METHOD_PRIVATE(mysqlnd_azure_data, dtor)(MYSQLND_CONN_DATA * conn)
-{
-	DBG_ENTER("mysqlnd_azure_data::dtor");
-	MYSQLND_AZURE_CONN_DATA** props = (MYSQLND_AZURE_CONN_DATA**)mysqlnd_plugin_get_plugin_connection_data_data(conn, mysqlnd_azure_plugin_id);
-
-	if (props && *props) {
-		mnd_pefree((*props), conn->persistent);
-		*props = NULL;
-	}
-
-	DBG_RETURN(org_conn_d_m.dtor(conn));
-}
-/* }}} */
-
-/* {{{ mysqlnd_azure_get_is_using_redirect */
-MYSQLND_AZURE_CONN_DATA**
-mysqlnd_azure_get_is_using_redirect(const MYSQLND_CONN_DATA *conn)
-{
-	MYSQLND_AZURE_CONN_DATA** props = NULL;
-	props = (MYSQLND_AZURE_CONN_DATA**)mysqlnd_plugin_get_plugin_connection_data_data(conn, mysqlnd_azure_plugin_id);
-	if (!props || !(*props)) {
-		*props = mnd_pemalloc(sizeof(MYSQLND_AZURE_CONN_DATA), conn->persistent);
-        if(!props  || !(*props)) {
-            return NULL;
-        }
-		(*props)->is_using_redirect = 0;
-	}
-	return props;
-}
-/* }}} */
-
-/* {{{ mysqlnd_azure_set_is_using_redirect */
-MYSQLND_AZURE_CONN_DATA**
-mysqlnd_azure_set_is_using_redirect(MYSQLND_CONN_DATA *conn, zend_bool is_using_redirect)
-{
-	MYSQLND_AZURE_CONN_DATA** props = NULL;
-	props = (MYSQLND_AZURE_CONN_DATA**)mysqlnd_plugin_get_plugin_connection_data_data(conn, mysqlnd_azure_plugin_id);
-	if (!props || !(*props)) {
-		*props = mnd_pemalloc(sizeof(MYSQLND_AZURE_CONN_DATA), conn->persistent);
-        if(!props  || !(*props)) {
-            return NULL;
-        }
-	}
-	(*props)->is_using_redirect = is_using_redirect;
-	return props;
-}
-/* }}} */
-
 /* {{{ set_redirect_client_options */
 static enum_func_status
 set_redirect_client_options(MYSQLND_CONN_DATA * const conn, MYSQLND_CONN_DATA * const redirectConn)
@@ -394,14 +343,9 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
 		}
 
 		//Get here means serverSupportRedirect
-		MYSQLND_AZURE_CONN_DATA** pdata = mysqlnd_azure_get_is_using_redirect(conn);
-        if(pdata==NULL) {
-			//mysqlnd_azure_get_is_using_redirect failed due to oom, do nothing here, just keep go with original connection if still usable.
-			goto after_conn;
-        }
 
 		//Already use redirected connection, or the connection string is a redirected one
-		if ((*pdata)->is_using_redirect || (strcmp(redirect_host, hostname.s) == 0 && strcmp(redirect_user, username.s) == 0 && ui_redirect_port == port)) {
+		if (strcmp(redirect_host, hostname.s) == 0 && strcmp(redirect_user, username.s) == 0 && ui_redirect_port == port) {
 			DBG_ENTER("[redirect]: Is using redirection, or redirection info are equal to origin, no need to redirect");
 			goto after_conn;
 		}
@@ -430,14 +374,6 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
 			}
 
 			//init redirect_conn succeeded, use this conn to start a new connection and handshake
-
-            //set is_using_redirect flag
-			MYSQLND_AZURE_CONN_DATA** data_ret = mysqlnd_azure_set_is_using_redirect(redirect_conn, 1);
-            if(data_ret==NULL) {
-                //mysqlnd_azure_set_is_using_redirect failed due to oom, do nothing here, just keep go with original connection if still usable.
-                redirect_conn->m->dtor(redirect_conn);
-                goto after_conn;
-            }
 
 			const MYSQLND_CSTRING redirect_hostname = { redirect_host, strlen(redirect_host) };
 			const MYSQLND_CSTRING redirect_username = { redirect_user, strlen(redirect_user) };
@@ -475,9 +411,6 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
 
 			}
 			else { //redirect failed. use original connection information
-
-				//clear is_using_redirect flag. This step is not need explictly, since object redirect_conn will be destroyed
-				//MYSQLND_AZURE_CONN_DATA** data_ret = mysqlnd_azure_set_is_using_redirect(redirect_conn, 0);
 
 				//free resource, and use original connection information
 				redirect_conn->m->dtor(redirect_conn);
@@ -667,22 +600,10 @@ MYSQLND_METHOD(mysqlnd_azure, connect)(MYSQLND * conn_handle,
 					const MYSQLND_CSTRING redirect_host = { redirect_info->redirect_host, strlen(redirect_info->redirect_host) };
 					const MYSQLND_CSTRING redirect_user = { redirect_info->redirect_user, strlen(redirect_info->redirect_user) };
 
-					MYSQLND_AZURE_CONN_DATA** data_ret = mysqlnd_azure_set_is_using_redirect(*pconn, 1);
-                    if(data_ret==NULL) {
-                        SET_OOM_ERROR((*pconn)->error_info);
-                        return FAIL;
-                    }
-
 					ret = (*pconn)->m->connect(pconn, redirect_host, redirect_user, password, database, redirect_info->redirect_port, socket_or_pipe, mysql_flags);
 					if (ret == FAIL) {
 						//remove invalid cache
 						mysqlnd_azure_remove_redirect_cache(username.s, hostname.s, port);
-
-						MYSQLND_AZURE_CONN_DATA** data_ret = mysqlnd_azure_set_is_using_redirect(*pconn, 0);
-                        if(data_ret==NULL) {
-                            SET_OOM_ERROR((*pconn)->error_info);
-                            return FAIL;
-                        }
 
 						ret = (*pconn)->m->connect(pconn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);
 					}
@@ -715,7 +636,6 @@ void mysqlnd_azure_minit_register_hooks()
 
 	conn_m->connect = MYSQLND_METHOD(mysqlnd_azure, connect);
 	conn_d_m->connect = MYSQLND_METHOD(mysqlnd_azure_data, connect);
-	conn_d_m->dtor = MYSQLND_METHOD_PRIVATE(mysqlnd_azure_data, dtor);
 }
 
 /* }}} */

--- a/mysqlnd_azure.c
+++ b/mysqlnd_azure.c
@@ -219,11 +219,14 @@ get_redirect_info(const MYSQLND_CONN_DATA * const conn, char* redirect_host, cha
     }
 
     char  redirect_port[8] = { 0 };
+    memcpy(redirect_port, port_begin, port_len);
+    *p_ui_redirect_port = atoi(redirect_port);
+    if(*p_ui_redirect_port <=0) {
+        return FALSE;
+    }
 
     memcpy(redirect_host, host_begin, host_len);
     memcpy(redirect_user, user_begin, user_len);
-    memcpy(redirect_port, port_begin, port_len);
-    *p_ui_redirect_port = atoi(redirect_port);
 
     return TRUE;
 }

--- a/mysqlnd_azure.h
+++ b/mysqlnd_azure.h
@@ -2,7 +2,7 @@
   +----------------------------------------------------------------------+
   | PHP Version 7                                                        |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2006-2018 The PHP Group                                |
+  | Copyright (c) The PHP Group                                          |
   +----------------------------------------------------------------------+
   | This source file is subject to version 3.01 of the PHP license,      |
   | that is bundled with this package in the file LICENSE, and is        |

--- a/mysqlnd_azure.h
+++ b/mysqlnd_azure.h
@@ -26,11 +26,6 @@
 #include "ext/mysqlnd/mysqlnd.h"
 #include "ext/mysqlnd/mysqlnd_debug.h"
 
-/* data which we will associate with a mysqlnd connection for redirection */
-typedef struct st_mysqlnd_azure_conn_data {
-	zend_bool is_using_redirect;
-} MYSQLND_AZURE_CONN_DATA;
-
 /*struct to store redirection chache info in hash table*/
 typedef struct st_mysqlnd_azure_redirect_info {
 	char* redirect_user;
@@ -43,8 +38,6 @@ typedef struct st_mysqlnd_azure_redirect_info {
 
 void mysqlnd_azure_minit_register_hooks();
 
-MYSQLND_AZURE_CONN_DATA** mysqlnd_azure_get_is_using_redirect(const MYSQLND_CONN_DATA *conn);
-MYSQLND_AZURE_CONN_DATA** mysqlnd_azure_set_is_using_redirect(MYSQLND_CONN_DATA *conn, zend_bool is_using_redirect);
 enum_func_status mysqlnd_azure_add_redirect_cache(const char* user, const char* host, int port, const char* redirect_user, const char* redirect_host, int redirect_port);
 enum_func_status mysqlnd_azure_remove_redirect_cache(const char* user, const char* host, int port);
 MYSQLND_AZURE_REDIRECT_INFO* mysqlnd_azure_find_redirect_cache(const char* user, const char* host, int port);

--- a/mysqlnd_azure.h
+++ b/mysqlnd_azure.h
@@ -28,9 +28,9 @@
 
 /*struct to store redirection chache info in hash table*/
 typedef struct st_mysqlnd_azure_redirect_info {
-	char* redirect_user;
-	char* redirect_host;
-	unsigned int redirect_port;
+    char* redirect_user;
+    char* redirect_host;
+    unsigned int redirect_port;
 } MYSQLND_AZURE_REDIRECT_INFO;
 
 #define MAX_REDIRECT_HOST_LEN 128
@@ -46,5 +46,5 @@ MYSQLND_AZURE_REDIRECT_INFO* mysqlnd_azure_find_redirect_cache(const char* user,
 ZEND_TSRMLS_CACHE_EXTERN()
 #endif
 
-#endif	/* MYSQLND_AZURE_H */
+#endif  /* MYSQLND_AZURE_H */
 

--- a/package.xml
+++ b/package.xml
@@ -16,7 +16,7 @@
   <email>Qianqian.Bu@microsoft.com</email>
   <active>yes</active>
  </lead>
- <date>2020-02-04</date>
+ <date>2020-02-05</date>
  <time>17:00:13</time>
  <version>
   <release>1.0.3</release>
@@ -28,7 +28,7 @@
  </stability>
  <license uri="http://www.php.net/license">PHP License</license>
  <notes>
-- Remove the is_using_redirect flag
+- Remove the use of is_using_redirect flag. More strict validation and test cases with embedded web server.
  </notes>
  <contents>
   <dir name="/">
@@ -44,6 +44,13 @@
    <file md5sum="271878ad9afcd0f4304529ff9522e034" name="tests/connect.inc" role="test" />
    <file md5sum="d621e9a3ad808225480ee11b361338ad" name="tests/skipif.inc" role="test" />
    <file md5sum="841204de228db4ea0150bf7289956163" name="tests/skipifconnectfailure.inc" role="test" />
+   <file md5sum="c5ac2a622a1ad2ecbb1a80fddb1ea774" name="tests/server.inc" role="test" />
+   <file md5sum="ee9b26d984fe6024f9ee9d6c162b3a1d" name="tests/skipif_pdo.inc" role="test" />
+   <file md5sum="9ecaa780d20d362faeae7df543a0d38f" name="tests/skipif_server.inc" role="test" />
+   <file md5sum="280ebbbe7bfbee3f9f50f3872ce58375" name="tests/server_basic_mysqli.phpt" role="test" />
+   <file md5sum="d6e763bef7cb06cd23db8b6416e50701" name="tests/server_basic_mysqli_testcase.php" role="test" />
+   <file md5sum="02d8e393486d59fb84866c03996489d1" name="tests/server_basic_pdo.phpt" role="test" />
+   <file md5sum="2b98d0e792fa35bb67fa7f196f05f7ca" name="tests/server_basic_pdo_testcase.php" role="test" />
    <file md5sum="a898ba9138cb8ebe9751d0629ebdcd87" name="LICENSE.txt" role="doc" />
    <file md5sum="c3de6c763e44bebab12cfa0d85c37fa0" name="Notes.txt" role="doc" />
    <file md5sum="2e6b1acdbd3ea3056847cbd5d8042153" name="CREDITS" role="doc" />
@@ -74,10 +81,10 @@
       <release>stable</release>
       <api>stable</api>
      </stability>
-     <date>2020-02-04</date>
+     <date>2020-02-05</date>
      <license uri="http://www.php.net/license">PHP License</license>
      <notes>
-Remove the is_using_redirect flag
+Remove the use of is_using_redirect flag. More strict validation and test cases with embedded web server.
      </notes>
     </release>
     <release>

--- a/package.xml
+++ b/package.xml
@@ -16,8 +16,8 @@
   <email>Qianqian.Bu@microsoft.com</email>
   <active>yes</active>
  </lead>
- <date>2020-02-05</date>
- <time>17:00:13</time>
+ <date>2020-02-10</date>
+ <time>15:00:13</time>
  <version>
   <release>1.0.3</release>
   <api>1.0.3</api>
@@ -28,7 +28,7 @@
  </stability>
  <license uri="http://www.php.net/license">PHP License</license>
  <notes>
-- Remove the use of is_using_redirect flag. More strict validation and test cases with embedded web server.
+- Remove the use of is_using_redirect flag. More strict validation and test cases with php built-in web server.
  </notes>
  <contents>
   <dir name="/">
@@ -81,10 +81,10 @@
       <release>stable</release>
       <api>stable</api>
      </stability>
-     <date>2020-02-05</date>
+     <date>2020-02-10</date>
      <license uri="http://www.php.net/license">PHP License</license>
      <notes>
-Remove the use of is_using_redirect flag. More strict validation and test cases with embedded web server.
+Remove the use of is_using_redirect flag. More strict validation and test cases with php built-in web server.
      </notes>
     </release>
     <release>

--- a/package.xml
+++ b/package.xml
@@ -16,20 +16,19 @@
   <email>Qianqian.Bu@microsoft.com</email>
   <active>yes</active>
  </lead>
- <date>2020-01-16</date>
+ <date>2020-02-04</date>
  <time>17:00:13</time>
  <version>
-  <release>1.0.3RC</release>
-  <api>1.0.3RC</api>
+  <release>1.0.3</release>
+  <api>1.0.3</api>
  </version>
  <stability>
-  <release>beta</release>
-  <api>beta</api>
+  <release>stable</release>
+  <api>stable</api>
  </stability>
  <license uri="http://www.php.net/license">PHP License</license>
  <notes>
-- apply fix for the crash problem when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false.
-- avoid redirect when ssl is false. Other performance improvement and refactor.
+- Remove the is_using_redirect flag
  </notes>
  <contents>
   <dir name="/">
@@ -66,6 +65,21 @@
  <providesextension>mysqlnd_azure</providesextension>
  <extsrcrelease />
  <changelog>
+    <release>
+     <version>
+     <release>1.0.3</release>
+     <api>1.0.3</api>
+     </version>
+     <stability>
+      <release>stable</release>
+      <api>stable</api>
+     </stability>
+     <date>2020-02-04</date>
+     <license uri="http://www.php.net/license">PHP License</license>
+     <notes>
+Remove the is_using_redirect flag
+     </notes>
+    </release>
     <release>
      <version>
      <release>1.0.3RC</release>

--- a/php_mysqlnd_azure.c
+++ b/php_mysqlnd_azure.c
@@ -2,7 +2,7 @@
   +----------------------------------------------------------------------+
   | PHP Version 7                                                        |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2006-2018 The PHP Group                                |
+  | Copyright (c) The PHP Group                                          |
   +----------------------------------------------------------------------+
   | This source file is subject to version 3.01 of the PHP license,      |
   | that is bundled with this package in the file LICENSE, and is        |

--- a/php_mysqlnd_azure.c
+++ b/php_mysqlnd_azure.c
@@ -32,29 +32,29 @@ ZEND_DECLARE_MODULE_GLOBALS(mysqlnd_azure)
 static PHP_GINIT_FUNCTION(mysqlnd_azure)
 {
 #if defined(COMPILE_DL_MYSQLND_AZURE) && defined(ZTS)
-	ZEND_TSRMLS_CACHE_UPDATE();
+    ZEND_TSRMLS_CACHE_UPDATE();
 #endif
-	mysqlnd_azure_globals->enabled = 0;
-	mysqlnd_azure_globals->redirectCache = NULL;
+    mysqlnd_azure_globals->enabled = 0;
+    mysqlnd_azure_globals->redirectCache = NULL;
 }
 /* }}} */
 
 /* {{{ PHP_GSHUTDOWN_FUNCTION */
 static PHP_GSHUTDOWN_FUNCTION(mysqlnd_azure)
 {
-	if (mysqlnd_azure_globals->redirectCache) {
-		zend_hash_destroy(mysqlnd_azure_globals->redirectCache);
-		mnd_pefree(mysqlnd_azure_globals->redirectCache, 1);
-		mysqlnd_azure_globals->redirectCache = NULL;
-	}
+    if (mysqlnd_azure_globals->redirectCache) {
+        zend_hash_destroy(mysqlnd_azure_globals->redirectCache);
+        mnd_pefree(mysqlnd_azure_globals->redirectCache, 1);
+        mysqlnd_azure_globals->redirectCache = NULL;
+    }
 }
 /* }}} */
 
 /* {{{ PHP_INI */
 /*
-	It is handy to allow users to disable any mysqlnd plugin globally - not only for debugging :-)
-	Because we register our plugin in MINIT changes to mysqlnd_ed.enabled shall be bound to
-	INI_SYSTEM (and PHP restarts).
+    It is handy to allow users to disable any mysqlnd plugin globally - not only for debugging :-)
+    Because we register our plugin in MINIT changes to mysqlnd_ed.enabled shall be bound to
+    INI_SYSTEM (and PHP restarts).
 */
 PHP_INI_BEGIN()
 STD_PHP_INI_ENTRY("mysqlnd_azure.enabled", "0", PHP_INI_ALL, OnUpdateBool, enabled, zend_mysqlnd_azure_globals, mysqlnd_azure_globals)
@@ -77,45 +77,45 @@ static PHP_MINIT_FUNCTION(mysqlnd_azure)
  */
 static PHP_MSHUTDOWN_FUNCTION(mysqlnd_azure)
 {
-	UNREGISTER_INI_ENTRIES();
+    UNREGISTER_INI_ENTRIES();
 
-	return SUCCESS;
+    return SUCCESS;
 }
 
 /* {{{ PHP_MINFO_FUNCTION
  */
 PHP_MINFO_FUNCTION(mysqlnd_azure)
 {
-	php_info_print_table_start();
-	php_info_print_table_header(2, "mysqlnd_azure", "enabled");
-	php_info_print_table_row(2, "enabled", MYSQLND_AZURE_G(enabled)? "Yes":"No");
-	php_info_print_table_end();
+    php_info_print_table_start();
+    php_info_print_table_header(2, "mysqlnd_azure", "enabled");
+    php_info_print_table_row(2, "enabled", MYSQLND_AZURE_G(enabled)? "Yes":"No");
+    php_info_print_table_end();
 }
 /* }}} */
 
 static const zend_module_dep mysqlnd_azure_deps[] = {
-	ZEND_MOD_REQUIRED("mysqlnd")
-	ZEND_MOD_END
+    ZEND_MOD_REQUIRED("mysqlnd")
+    ZEND_MOD_END
 };
 
 /* {{{ mysqlnd_azure_module_entry*/
 zend_module_entry mysqlnd_azure_module_entry = {
-	STANDARD_MODULE_HEADER_EX,
-	NULL,
-	mysqlnd_azure_deps,
-	EXT_MYSQLND_AZURE_NAME,
-	NULL,
-	PHP_MINIT(mysqlnd_azure),
-	PHP_MSHUTDOWN(mysqlnd_azure),
-	NULL,
-	NULL,
-	PHP_MINFO(mysqlnd_azure),
-	EXT_MYSQLND_AZURE_VERSION,
-	PHP_MODULE_GLOBALS(mysqlnd_azure),
-	PHP_GINIT(mysqlnd_azure),
-	PHP_GSHUTDOWN(mysqlnd_azure),
-	NULL,
-	STANDARD_MODULE_PROPERTIES_EX
+    STANDARD_MODULE_HEADER_EX,
+    NULL,
+    mysqlnd_azure_deps,
+    EXT_MYSQLND_AZURE_NAME,
+    NULL,
+    PHP_MINIT(mysqlnd_azure),
+    PHP_MSHUTDOWN(mysqlnd_azure),
+    NULL,
+    NULL,
+    PHP_MINFO(mysqlnd_azure),
+    EXT_MYSQLND_AZURE_VERSION,
+    PHP_MODULE_GLOBALS(mysqlnd_azure),
+    PHP_GINIT(mysqlnd_azure),
+    PHP_GSHUTDOWN(mysqlnd_azure),
+    NULL,
+    STANDARD_MODULE_PROPERTIES_EX
 };
 /* }}} */
 

--- a/php_mysqlnd_azure.h
+++ b/php_mysqlnd_azure.h
@@ -2,7 +2,7 @@
   +----------------------------------------------------------------------+
   | PHP Version 7                                                        |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2006-2018 The PHP Group                                |
+  | Copyright (c) The PHP Group                                          |
   +----------------------------------------------------------------------+
   | This source file is subject to version 3.01 of the PHP license,      |
   | that is bundled with this package in the file LICENSE, and is        |

--- a/php_mysqlnd_azure.h
+++ b/php_mysqlnd_azure.h
@@ -32,12 +32,12 @@ extern zend_module_entry mysqlnd_azure_module_entry;
 #define EXT_MYSQLND_AZURE_VERSION   "1.0.3"
 
 ZEND_BEGIN_MODULE_GLOBALS(mysqlnd_azure)
-	zend_bool		enabled;
-	HashTable*		redirectCache;
+    zend_bool       enabled;
+    HashTable*      redirectCache;
 ZEND_END_MODULE_GLOBALS(mysqlnd_azure)
 
 PHPAPI ZEND_EXTERN_MODULE_GLOBALS(mysqlnd_azure)
 #define MYSQLND_AZURE_G(v) ZEND_MODULE_GLOBALS_ACCESSOR(mysqlnd_azure, v)
 
-#endif	/* PHP_MYSQLND_AZURE_H */
+#endif  /* PHP_MYSQLND_AZURE_H */
 

--- a/php_mysqlnd_azure.h
+++ b/php_mysqlnd_azure.h
@@ -29,7 +29,7 @@ extern zend_module_entry mysqlnd_azure_module_entry;
 #define phpext_mysqlnd_azure_ptr &mysqlnd_azure_module_entry
 
 #define EXT_MYSQLND_AZURE_NAME      "mysqlnd_azure"
-#define EXT_MYSQLND_AZURE_VERSION   "1.0.3RC"
+#define EXT_MYSQLND_AZURE_VERSION   "1.0.3"
 
 ZEND_BEGIN_MODULE_GLOBALS(mysqlnd_azure)
 	zend_bool		enabled;

--- a/redirect_cache.c
+++ b/redirect_cache.c
@@ -2,7 +2,7 @@
   +----------------------------------------------------------------------+
   | PHP Version 7                                                        |
   +----------------------------------------------------------------------+
-  | Copyright (c) 2006-2018 The PHP Group                                |
+  | Copyright (c) The PHP Group                                          |
   +----------------------------------------------------------------------+
   | This source file is subject to version 3.01 of the PHP license,      |
   | that is bundled with this package in the file LICENSE, and is        |

--- a/redirect_cache.c
+++ b/redirect_cache.c
@@ -32,7 +32,7 @@
 /* {{{ mysqlnd_azure_redirect_info_dtor */
 static void mysqlnd_azure_redirect_info_dtor(zval *zv)
 {
-	MYSQLND_AZURE_REDIRECT_INFO *redirect_info = (MYSQLND_AZURE_REDIRECT_INFO*)Z_PTR_P(zv);
+    MYSQLND_AZURE_REDIRECT_INFO *redirect_info = (MYSQLND_AZURE_REDIRECT_INFO*)Z_PTR_P(zv);
 
     if (redirect_info != NULL) {
 
@@ -45,8 +45,8 @@ static void mysqlnd_azure_redirect_info_dtor(zval *zv)
             redirect_info->redirect_host = NULL;
         }
 
-		mnd_pefree(redirect_info, 1);
-		redirect_info = NULL;
+        mnd_pefree(redirect_info, 1);
+        redirect_info = NULL;
       
     }
 
@@ -56,34 +56,34 @@ static void mysqlnd_azure_redirect_info_dtor(zval *zv)
 /* {{{ mysqlnd_azure_add_redirect_cache */
 enum_func_status mysqlnd_azure_add_redirect_cache(const char* user, const char* host, int port, const char* redirect_user, const char* redirect_host, int redirect_port)
 {
-	if (MYSQLND_AZURE_G(redirectCache) == NULL) {
-		MYSQLND_AZURE_G(redirectCache) = mnd_pemalloc(sizeof(HashTable), 1);
+    if (MYSQLND_AZURE_G(redirectCache) == NULL) {
+        MYSQLND_AZURE_G(redirectCache) = mnd_pemalloc(sizeof(HashTable), 1);
         if(MYSQLND_AZURE_G(redirectCache) == NULL) {
             return FAIL;
         }
-		zend_hash_init(MYSQLND_AZURE_G(redirectCache), 0, NULL, mysqlnd_azure_redirect_info_dtor, 1);
-	}
+        zend_hash_init(MYSQLND_AZURE_G(redirectCache), 0, NULL, mysqlnd_azure_redirect_info_dtor, 1);
+    }
 
-	char* key = NULL;
-	mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN+ MAX_REDIRECT_USER_LEN+8, "%s_%s_%d", user, host, port);
+    char* key = NULL;
+    mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN+ MAX_REDIRECT_USER_LEN+8, "%s_%s_%d", user, host, port);
     if(!key) {
         return FAIL;
     }
 
-	MYSQLND_AZURE_REDIRECT_INFO* redirect_info = pemalloc(sizeof(MYSQLND_AZURE_REDIRECT_INFO), 1);
+    MYSQLND_AZURE_REDIRECT_INFO* redirect_info = pemalloc(sizeof(MYSQLND_AZURE_REDIRECT_INFO), 1);
     if(redirect_info == NULL) {
         return FAIL;
     }
-	redirect_info->redirect_user = mnd_pestrndup(redirect_user, strlen(redirect_user), 1);
-	redirect_info->redirect_host = mnd_pestrndup(redirect_host, strlen(redirect_host), 1);
+    redirect_info->redirect_user = mnd_pestrndup(redirect_user, strlen(redirect_user), 1);
+    redirect_info->redirect_host = mnd_pestrndup(redirect_host, strlen(redirect_host), 1);
     if(redirect_info->redirect_user == NULL || redirect_info->redirect_host == NULL) {
         return FAIL;
     }
-	redirect_info->redirect_port = redirect_port;
+    redirect_info->redirect_port = redirect_port;
 
-	zend_hash_str_update_ptr(MYSQLND_AZURE_G(redirectCache), key, strlen(key), redirect_info);
+    zend_hash_str_update_ptr(MYSQLND_AZURE_G(redirectCache), key, strlen(key), redirect_info);
 
-	mnd_sprintf_free(key);
+    mnd_sprintf_free(key);
 
     return PASS;
 }
@@ -92,7 +92,7 @@ enum_func_status mysqlnd_azure_add_redirect_cache(const char* user, const char* 
 /* {{{ mysqlnd_azure_remove_redirect_cache */
 enum_func_status mysqlnd_azure_remove_redirect_cache(const char* user, const char* host, int port)
 {
-	if (MYSQLND_AZURE_G(redirectCache) != NULL) {
+    if (MYSQLND_AZURE_G(redirectCache) != NULL) {
         char *key = NULL;
         mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN + MAX_REDIRECT_USER_LEN + 8, "%s_%s_%d", user, host, port);
         if(!key) {
@@ -103,14 +103,14 @@ enum_func_status mysqlnd_azure_remove_redirect_cache(const char* user, const cha
         mnd_sprintf_free(key);
     }
 
-	return PASS;
+    return PASS;
 }
 /* }}} */
 
 /* {{{ mysqlnd_azure_find_redirect_cache */
 MYSQLND_AZURE_REDIRECT_INFO* mysqlnd_azure_find_redirect_cache(const char* user, const char* host, int port)
 {
-	if (MYSQLND_AZURE_G(redirectCache) != NULL) {
+    if (MYSQLND_AZURE_G(redirectCache) != NULL) {
         char *key = NULL;
         mnd_sprintf(&key, MAX_REDIRECT_HOST_LEN + MAX_REDIRECT_USER_LEN + 8, "%s_%s_%d", user, host, port);
         if(!key) {

--- a/tests/connect.inc
+++ b/tests/connect.inc
@@ -1,25 +1,25 @@
 <?php
-	/*
-	Default values are "localhost", "root",
-	database "stest" and empty password.
-	Change the MYSQL_TEST environment values
-	if you want to use another configuration
-	*/
+    /*
+    Default values are "localhost", "root",
+    database "stest" and empty password.
+    Change the MYSQL_TEST environment values
+    if you want to use another configuration
+    */
 
-	$driver    = new mysqli_driver;
+    $driver    = new mysqli_driver;
 
-	$host      = getenv("MYSQL_TEST_HOST")     ? getenv("MYSQL_TEST_HOST") : "localhost";
-	$port      = getenv("MYSQL_TEST_PORT")     ? getenv("MYSQL_TEST_PORT") : 3306;
-	$user      = getenv("MYSQL_TEST_USER")     ? getenv("MYSQL_TEST_USER") : "root";
-	$passwd    = getenv("MYSQL_TEST_PASSWD")   ? getenv("MYSQL_TEST_PASSWD") : "";
-	$db        = getenv("MYSQL_TEST_DB")       ? getenv("MYSQL_TEST_DB") : NULL;
-	$engine    = getenv("MYSQL_TEST_ENGINE")   ? getenv("MYSQL_TEST_ENGINE") : "InnoDB";
-	$pdo_dsn		= getenv("PDO_MYSQL_TEST_DSN")   ? getenv("PDO_MYSQL_TEST_DSN") : "mysql:host=".$host.";dbname=".$db;
-	$ssl_cert_file	= getenv("MYSQL_SSL_CERT_FILE")   ? getenv("MYSQL_SSL_CERT_FILE") : NULL;
+    $host      = getenv("MYSQL_TEST_HOST")     ? getenv("MYSQL_TEST_HOST") : "localhost";
+    $port      = getenv("MYSQL_TEST_PORT")     ? getenv("MYSQL_TEST_PORT") : 3306;
+    $user      = getenv("MYSQL_TEST_USER")     ? getenv("MYSQL_TEST_USER") : "root";
+    $passwd    = getenv("MYSQL_TEST_PASSWD")   ? getenv("MYSQL_TEST_PASSWD") : "";
+    $db        = getenv("MYSQL_TEST_DB")       ? getenv("MYSQL_TEST_DB") : NULL;
+    $engine    = getenv("MYSQL_TEST_ENGINE")   ? getenv("MYSQL_TEST_ENGINE") : "InnoDB";
+    $pdo_dsn        = getenv("PDO_MYSQL_TEST_DSN")   ? getenv("PDO_MYSQL_TEST_DSN") : "mysql:host=".$host.";dbname=".$db;
+    $ssl_cert_file  = getenv("MYSQL_SSL_CERT_FILE")   ? getenv("MYSQL_SSL_CERT_FILE") : NULL;
 
-	$IS_MYSQLND = stristr(mysqli_get_client_info(), "mysqlnd");
-	if (!$IS_MYSQLND) {
-		die('skip mysqlnd extension not available');
-	}
+    $IS_MYSQLND = stristr(mysqli_get_client_info(), "mysqlnd");
+    if (!$IS_MYSQLND) {
+        die('skip mysqlnd extension not available');
+    }
 
 ?>

--- a/tests/connect.inc
+++ b/tests/connect.inc
@@ -14,6 +14,8 @@
 	$passwd    = getenv("MYSQL_TEST_PASSWD")   ? getenv("MYSQL_TEST_PASSWD") : "";
 	$db        = getenv("MYSQL_TEST_DB")       ? getenv("MYSQL_TEST_DB") : NULL;
 	$engine    = getenv("MYSQL_TEST_ENGINE")   ? getenv("MYSQL_TEST_ENGINE") : "InnoDB";
+	$pdo_dsn		= getenv("PDO_MYSQL_TEST_DSN")   ? getenv("PDO_MYSQL_TEST_DSN") : "mysql:host=".$host.";dbname=".$db;
+	$ssl_cert_file	= getenv("MYSQL_SSL_CERT_FILE")   ? getenv("MYSQL_SSL_CERT_FILE") : NULL;
 
 	$IS_MYSQLND = stristr(mysqli_get_client_info(), "mysqlnd");
 	if (!$IS_MYSQLND) {

--- a/tests/mysqli_azure_redirection_disabled.phpt
+++ b/tests/mysqli_azure_redirection_disabled.phpt
@@ -12,22 +12,22 @@ mysqlnd_azure.enabled=0
 require_once("connect.inc");
 
 if (($tmp = ini_get("mysqlnd_azure.enabled")) != false)
-		printf("[001] mysqlnd_azure.enabled not set to false, got '%s'\n", $tmp);
+        printf("[001] mysqlnd_azure.enabled not set to false, got '%s'\n", $tmp);
 
 $link = mysqli_init();
 $ret = mysqli_real_connect($link, $host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
 if (!$ret || !is_object($link))
 {
-	printf("[002] Cannot connect to the server with ssl using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n  - [%d] %s",
-			$host, $user, $db, $port, $socket, mysqli_connect_errno(), mysqli_connect_error());
-	die();
+    printf("[002] Cannot connect to the server with ssl using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n  - [%d] %s",
+            $host, $user, $db, $port, $socket, mysqli_connect_errno(), mysqli_connect_error());
+    die();
 }
 echo $link->host_info."\n";
 echo $link->info."\n";
 if(substr($link->host_info, 0, strlen($host)) == $host)
-	echo "1\n";
+    echo "1\n";
 else
-	echo "0\n";
+    echo "0\n";
 mysqli_close($link);
 echo "Done\n";
 ?>

--- a/tests/mysqli_azure_redirection_enabled.phpt
+++ b/tests/mysqli_azure_redirection_enabled.phpt
@@ -12,22 +12,22 @@ require_once('skipifconnectfailure.inc');
 require_once("connect.inc");
 
 if (($tmp = ini_get("mysqlnd_azure.enabled")) != true)
-		printf("[001] mysqlnd_azure.enabled not set to true, got '%s'\n", $tmp);
+        printf("[001] mysqlnd_azure.enabled not set to true, got '%s'\n", $tmp);
 
 $link = mysqli_init();
 $ret = mysqli_real_connect($link, $host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
 if (!$ret || !is_object($link))
 {
-	printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n  - [%d] %s with ssl",
-			$host, $user, $db, $port, $socket, mysqli_connect_errno(), mysqli_connect_error());
-	die();
+    printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n  - [%d] %s with ssl",
+            $host, $user, $db, $port, $socket, mysqli_connect_errno(), mysqli_connect_error());
+    die();
 }
 echo $link->host_info."\n";
 echo $link->info."\n";
 if(substr($link->host_info, 0, strlen($host)) == $host)
-	echo "1\n";
+    echo "1\n";
 else
-	echo "0\n";
+    echo "0\n";
 mysqli_close($link);
 echo "Done\n";
 ?>

--- a/tests/server.inc
+++ b/tests/server.inc
@@ -1,0 +1,84 @@
+<?php
+
+define ("PHP_SERVER_HOSTNAME", "localhost");
+define ("PHP_SERVER_PORT", 8966);
+define ("PHP_SERVER_ADDRESS", PHP_SERVER_HOSTNAME.":".PHP_SERVER_PORT);
+
+function cli_server_start() {
+    if(getenv('PHP_HTTP_REMOTE_SERVER')) {
+        return getenv('PHP_HTTP_REMOTE_SERVER');
+    }
+
+    $php_executable = getenv('TEST_PHP_EXECUTABLE');
+    $doc_root = __DIR__;
+
+    if (substr(PHP_OS, 0, 3) == 'WIN') {
+        $descriptorspec = array(
+            0 => STDIN,
+            1 => STDOUT,
+            2 => array("pipe", "w"),
+        );
+
+        $cmd = "{$php_executable} -t {$doc_root} -S " . PHP_SERVER_ADDRESS;
+        //$cmd .= " {$router}";
+        $handle = proc_open(addslashes($cmd), $descriptorspec, $pipes, $doc_root, NULL, array("bypass_shell" => true,  "suppress_errors" => true));
+    } else {
+        $descriptorspec = array(
+            0 => STDIN,
+            1 => STDOUT,
+            2 => STDERR,
+        );
+
+        $cmd = "exec {$php_executable} -t {$doc_root} -S " . PHP_SERVER_ADDRESS;
+        //$cmd .= " {$router}";
+        $cmd .= " 2>/dev/null";
+
+        $handle = proc_open($cmd, $descriptorspec, $pipes, $doc_root);
+    }
+
+    // note: even when server prints 'Listening on localhost:8966...Press Ctrl-C to quit.'
+    //       it might not be listening yet...need to wait until fsockopen() call returns
+    $error = "Unable to connect to server\n";
+    for ($i=0; $i < 60; $i++) {
+        usleep(50000); // 50ms per try
+        $status = proc_get_status($handle);
+        $fp = @fsockopen(PHP_SERVER_HOSTNAME, PHP_SERVER_PORT);
+        // Failure, the server is no longer running
+        if (!($status && $status['running'])) {
+            $error = "Server is not running\n";
+            break;
+        }
+        // Success, Connected to servers
+        if ($fp) {
+            $error = '';
+            break;
+        }
+    }
+
+    if ($fp) {
+        fclose($fp);
+    }
+
+    if ($error) {
+        echo $error;
+        proc_terminate($handle);
+        exit(1);
+    }
+
+    register_shutdown_function(
+        function($handle)  {
+            proc_terminate($handle);
+            /* Wait for server to shutdown */
+            for ($i = 0; $i < 60; $i++) {
+                $status = proc_get_status($handle);
+                if (!($status && $status['running'])) {
+                    break;
+                }
+                usleep(50000);
+            }
+        },
+        $handle
+    );
+
+    return PHP_SERVER_ADDRESS;
+}

--- a/tests/server.inc
+++ b/tests/server.inc
@@ -20,7 +20,7 @@ function cli_server_start() {
         );
 
         $cmd = "{$php_executable} -t {$doc_root} -S " . PHP_SERVER_ADDRESS;
-        //$cmd .= " {$router}";
+
         $handle = proc_open(addslashes($cmd), $descriptorspec, $pipes, $doc_root, NULL, array("bypass_shell" => true,  "suppress_errors" => true));
     } else {
         $descriptorspec = array(
@@ -30,7 +30,7 @@ function cli_server_start() {
         );
 
         $cmd = "exec {$php_executable} -t {$doc_root} -S " . PHP_SERVER_ADDRESS;
-        //$cmd .= " {$router}";
+
         $cmd .= " 2>/dev/null";
 
         $handle = proc_open($cmd, $descriptorspec, $pipes, $doc_root);

--- a/tests/server_basic_mysqli.phpt
+++ b/tests/server_basic_mysqli.phpt
@@ -6,6 +6,8 @@ Test redirection in web server with baisc functionality - mysqli
     require_once('skipif.inc');
     require_once('skipifconnectfailure.inc');
 ?>
+--CONFLICTS--
+server
 --FILE--
 <?php
 include 'server.inc';

--- a/tests/server_basic_mysqli.phpt
+++ b/tests/server_basic_mysqli.phpt
@@ -2,7 +2,7 @@
 Test redirection in web server with baisc functionality - mysqli
 --SKIPIF--
 <?php 
-	require_once('skipif_server.inc');
+    require_once('skipif_server.inc');
     require_once('skipif.inc');
     require_once('skipifconnectfailure.inc');
 ?>
@@ -20,11 +20,11 @@ $url = "http://"."{$host}/server_basic_mysqli_testcase.php";
 
 $fp = fopen($url, 'r');
 if(!$fp) {
-	echo "[000] request url failed \n";
-	die();
+    echo "[000] request url failed \n";
+    die();
 }
 while (!feof($fp)) {
-	echo fgets($fp, 4096);
+    echo fgets($fp, 4096);
 }
 
 fclose($fp);

--- a/tests/server_basic_mysqli.phpt
+++ b/tests/server_basic_mysqli.phpt
@@ -1,0 +1,53 @@
+--TEST--
+Test redirection in web server with baisc functionality - mysqli
+--SKIPIF--
+<?php 
+	require_once('skipif_server.inc');
+    require_once('skipif.inc');
+    require_once('skipifconnectfailure.inc');
+?>
+--FILE--
+<?php
+include 'server.inc';
+$host = cli_server_start();
+
+// start testing
+echo "*** Testing mysqli in web server: basic functionality ***\n";
+
+$url = "http://"."{$host}/server_basic_mysqli_testcase.php";
+
+$fp = fopen($url, 'r');
+if(!$fp) {
+	echo "[000] request url failed \n";
+	die();
+}
+while (!feof($fp)) {
+	echo fgets($fp, 4096);
+}
+
+fclose($fp);
+?>
+===DONE===
+--EXPECTF--
+*** Testing mysqli in web server: basic functionality ***
+step1: redirect enabled, non-persistent connection 
+mysqlnd_azure.enabled: On
+%s
+Location: mysql://%s:%d/user=%s
+0
+step2: redirect enabled, persistent connection 
+mysqlnd_azure.enabled: On
+%s
+Location: mysql://%s:%d/user=%s
+0
+step3: redirect disabled, non-persistent connection 
+mysqlnd_azure.enabled: Off
+%s
+Location: mysql://%s:%d/user=%s
+1
+step4: redirect disabled, persistent connection 
+mysqlnd_azure.enabled: Off
+%s
+
+0
+===DONE===

--- a/tests/server_basic_mysqli_testcase.php
+++ b/tests/server_basic_mysqli_testcase.php
@@ -5,84 +5,84 @@ ini_set("mysqlnd_azure.enabled", "on");
 
 echo "step1: redirect enabled, non-persistent connection \n";
 {
-	echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
-	$link = mysqli_init();
-	$ret = mysqli_real_connect($link, $host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
-	if (!$ret || !is_object($link))
-	{
-		printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n  - [%d] %s with ssl",
-				$host, $user, $db, $port, $socket, mysqli_connect_errno(), mysqli_connect_error());
-		die();
-	}
-	echo $link->host_info."\n";
-	echo $link->info."\n";
-	if(substr($link->host_info, 0, strlen($host)) == $host)
-		echo "1\n";
-	else
-		echo "0\n";
-	mysqli_close($link);
+    echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
+    $link = mysqli_init();
+    $ret = mysqli_real_connect($link, $host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
+    if (!$ret || !is_object($link))
+    {
+        printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n  - [%d] %s with ssl",
+                $host, $user, $db, $port, $socket, mysqli_connect_errno(), mysqli_connect_error());
+        die();
+    }
+    echo $link->host_info."\n";
+    echo $link->info."\n";
+    if(substr($link->host_info, 0, strlen($host)) == $host)
+        echo "1\n";
+    else
+        echo "0\n";
+    mysqli_close($link);
 }
 
 echo "step2: redirect enabled, persistent connection \n";
 {
-	echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
-	$link = mysqli_init();
-	$ret = mysqli_real_connect($link, "p:".$host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
-	if (!$ret || !is_object($link))
-	{
-		printf("[002] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n  - [%d] %s with ssl",
-				$host, $user, $db, $port, $socket, mysqli_connect_errno(), mysqli_connect_error());
-		die();
-	}
-	echo $link->host_info."\n";
-	echo $link->info."\n";
-	if(substr($link->host_info, 0, strlen($host)) == $host)
-		echo "1\n";
-	else
-		echo "0\n";
-	mysqli_close($link);
+    echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
+    $link = mysqli_init();
+    $ret = mysqli_real_connect($link, "p:".$host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
+    if (!$ret || !is_object($link))
+    {
+        printf("[002] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n  - [%d] %s with ssl",
+                $host, $user, $db, $port, $socket, mysqli_connect_errno(), mysqli_connect_error());
+        die();
+    }
+    echo $link->host_info."\n";
+    echo $link->info."\n";
+    if(substr($link->host_info, 0, strlen($host)) == $host)
+        echo "1\n";
+    else
+        echo "0\n";
+    mysqli_close($link);
 }
 
 ini_set("mysqlnd_azure.enabled", 0);
 
 echo "step3: redirect disabled, non-persistent connection \n";
 {
-	echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
-	$link = mysqli_init();
-	$ret = mysqli_real_connect($link, $host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
-	if (!$ret || !is_object($link))
-	{
-		printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n  - [%d] %s with ssl",
-				$host, $user, $db, $port, $socket, mysqli_connect_errno(), mysqli_connect_error());
-		die();
-	}
-	echo $link->host_info."\n";
-	echo $link->info."\n";
-	if(substr($link->host_info, 0, strlen($host)) == $host)
-		echo "1\n";
-	else
-		echo "0\n";
-	mysqli_close($link);
+    echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
+    $link = mysqli_init();
+    $ret = mysqli_real_connect($link, $host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
+    if (!$ret || !is_object($link))
+    {
+        printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n  - [%d] %s with ssl",
+                $host, $user, $db, $port, $socket, mysqli_connect_errno(), mysqli_connect_error());
+        die();
+    }
+    echo $link->host_info."\n";
+    echo $link->info."\n";
+    if(substr($link->host_info, 0, strlen($host)) == $host)
+        echo "1\n";
+    else
+        echo "0\n";
+    mysqli_close($link);
 }
 
 echo "step4: redirect disabled, persistent connection \n";
 {
-	echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
-	$link = mysqli_init();
-	$ret = mysqli_real_connect($link, "p:".$host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
-	if (!$ret || !is_object($link))
-	{
-		printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n  - [%d] %s with ssl",
-				$host, $user, $db, $port, $socket, mysqli_connect_errno(), mysqli_connect_error());
-		die();
-	}
-	echo $link->host_info."\n";
-	echo $link->info."\n";
-	if(substr($link->host_info, 0, strlen($host)) == $host)
-		echo "1\n";
-	else
-		echo "0\n";
-	mysqli_close($link);
+    echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
+    $link = mysqli_init();
+    $ret = mysqli_real_connect($link, "p:".$host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
+    if (!$ret || !is_object($link))
+    {
+        printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n  - [%d] %s with ssl",
+                $host, $user, $db, $port, $socket, mysqli_connect_errno(), mysqli_connect_error());
+        die();
+    }
+    echo $link->host_info."\n";
+    echo $link->info."\n";
+    if(substr($link->host_info, 0, strlen($host)) == $host)
+        echo "1\n";
+    else
+        echo "0\n";
+    mysqli_close($link);
 }
 
 ?>

--- a/tests/server_basic_mysqli_testcase.php
+++ b/tests/server_basic_mysqli_testcase.php
@@ -1,0 +1,88 @@
+<?php
+require_once("connect.inc");
+
+ini_set("mysqlnd_azure.enabled", "on");
+
+echo "step1: redirect enabled, non-persistent connection \n";
+{
+	echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
+	$link = mysqli_init();
+	$ret = mysqli_real_connect($link, $host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
+	if (!$ret || !is_object($link))
+	{
+		printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n  - [%d] %s with ssl",
+				$host, $user, $db, $port, $socket, mysqli_connect_errno(), mysqli_connect_error());
+		die();
+	}
+	echo $link->host_info."\n";
+	echo $link->info."\n";
+	if(substr($link->host_info, 0, strlen($host)) == $host)
+		echo "1\n";
+	else
+		echo "0\n";
+	mysqli_close($link);
+}
+
+echo "step2: redirect enabled, persistent connection \n";
+{
+	echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
+	$link = mysqli_init();
+	$ret = mysqli_real_connect($link, "p:".$host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
+	if (!$ret || !is_object($link))
+	{
+		printf("[002] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n  - [%d] %s with ssl",
+				$host, $user, $db, $port, $socket, mysqli_connect_errno(), mysqli_connect_error());
+		die();
+	}
+	echo $link->host_info."\n";
+	echo $link->info."\n";
+	if(substr($link->host_info, 0, strlen($host)) == $host)
+		echo "1\n";
+	else
+		echo "0\n";
+	mysqli_close($link);
+}
+
+ini_set("mysqlnd_azure.enabled", 0);
+
+echo "step3: redirect disabled, non-persistent connection \n";
+{
+	echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
+	$link = mysqli_init();
+	$ret = mysqli_real_connect($link, $host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
+	if (!$ret || !is_object($link))
+	{
+		printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n  - [%d] %s with ssl",
+				$host, $user, $db, $port, $socket, mysqli_connect_errno(), mysqli_connect_error());
+		die();
+	}
+	echo $link->host_info."\n";
+	echo $link->info."\n";
+	if(substr($link->host_info, 0, strlen($host)) == $host)
+		echo "1\n";
+	else
+		echo "0\n";
+	mysqli_close($link);
+}
+
+echo "step4: redirect disabled, persistent connection \n";
+{
+	echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
+	$link = mysqli_init();
+	$ret = mysqli_real_connect($link, "p:".$host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
+	if (!$ret || !is_object($link))
+	{
+		printf("[001] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n  - [%d] %s with ssl",
+				$host, $user, $db, $port, $socket, mysqli_connect_errno(), mysqli_connect_error());
+		die();
+	}
+	echo $link->host_info."\n";
+	echo $link->info."\n";
+	if(substr($link->host_info, 0, strlen($host)) == $host)
+		echo "1\n";
+	else
+		echo "0\n";
+	mysqli_close($link);
+}
+
+?>

--- a/tests/server_basic_pdo.phpt
+++ b/tests/server_basic_pdo.phpt
@@ -2,7 +2,7 @@
 Test redirection in web server with baisc functionality - pdo_mysql
 --SKIPIF--
 <?php 
-	require_once('skipif_server.inc');
+    require_once('skipif_server.inc');
     require_once('skipif_pdo.inc');
 ?>
 --CONFLICTS--
@@ -19,11 +19,11 @@ $url = "http://"."{$host}/server_basic_pdo_testcase.php";
 
 $fp = fopen($url, 'r');
 if(!$fp) {
-	echo "[000] request url failed \n";
-	die();
+    echo "[000] request url failed \n";
+    die();
 }
 while (!feof($fp)) {
-	echo fgets($fp, 4096);
+    echo fgets($fp, 4096);
 }
 
 fclose($fp);

--- a/tests/server_basic_pdo.phpt
+++ b/tests/server_basic_pdo.phpt
@@ -1,0 +1,48 @@
+--TEST--
+Test redirection in web server with baisc functionality - pdo_mysql
+--SKIPIF--
+<?php 
+	require_once('skipif_server.inc');
+    require_once('skipif_pdo.inc');
+?>
+--FILE--
+<?php
+include 'server.inc';
+$host = cli_server_start();
+
+// start testing
+echo "*** Testing pdo_mysql in web server: basic functionality ***\n";
+
+$url = "http://"."{$host}/server_basic_pdo_testcase.php";
+
+$fp = fopen($url, 'r');
+if(!$fp) {
+	echo "[000] request url failed \n";
+	die();
+}
+while (!feof($fp)) {
+	echo fgets($fp, 4096);
+}
+
+fclose($fp);
+?>
+===DONE===
+--EXPECTF--
+*** Testing pdo_mysql in web server: basic functionality ***
+step1: redirect enabled, non-persistent connection 
+mysqlnd_azure.enabled: On
+%s
+0
+step2: redirect enabled, persistent connection 
+mysqlnd_azure.enabled: On
+%s
+0
+step3: redirect disabled, non-persistent connection 
+mysqlnd_azure.enabled: Off
+%s
+1
+step4: redirect disabled, persistent connection 
+mysqlnd_azure.enabled: Off
+%s
+0
+===DONE===

--- a/tests/server_basic_pdo.phpt
+++ b/tests/server_basic_pdo.phpt
@@ -5,6 +5,8 @@ Test redirection in web server with baisc functionality - pdo_mysql
 	require_once('skipif_server.inc');
     require_once('skipif_pdo.inc');
 ?>
+--CONFLICTS--
+server
 --FILE--
 <?php
 include 'server.inc';

--- a/tests/server_basic_pdo_testcase.php
+++ b/tests/server_basic_pdo_testcase.php
@@ -5,92 +5,92 @@ ini_set("mysqlnd_azure.enabled", "on");
 
 echo "step1: redirect enabled, non-persistent connection \n";
 {
-	echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
-	$conn = NULL;
+    echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
+    $conn = NULL;
     try {
-		$conn = new PDO($pdo_dsn, $user, $passwd, 
-					array(PDO::MYSQL_ATTR_SSL_CA => $ssl_cert_file, PDO::ATTR_PERSISTENT=>false));
-	}
-	catch (Exception $e) {
-		die ("[001] pdo connection failed. Exception: ".e.getMessage()."\n");
-	}
-	
-	$host_info = $conn->getAttribute(PDO::ATTR_CONNECTION_STATUS);
-	echo $host_info, "\n";
+        $conn = new PDO($pdo_dsn, $user, $passwd,
+                    array(PDO::MYSQL_ATTR_SSL_CA => $ssl_cert_file, PDO::ATTR_PERSISTENT=>false));
+    }
+    catch (Exception $e) {
+        die ("[001] pdo connection failed. Exception: ".e.getMessage()."\n");
+    }
 
-	if(substr($host_info, 0, strlen($host)) == $host)
-		echo "1\n";
-	else
-		echo "0\n";
-	$conn = NULL;
+    $host_info = $conn->getAttribute(PDO::ATTR_CONNECTION_STATUS);
+    echo $host_info, "\n";
+
+    if(substr($host_info, 0, strlen($host)) == $host)
+        echo "1\n";
+    else
+        echo "0\n";
+    $conn = NULL;
 }
 
 echo "step2: redirect enabled, persistent connection \n";
 {
-	echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
-	$conn = NULL;
+    echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
+    $conn = NULL;
     try {
-		$conn = new PDO($pdo_dsn, $user, $passwd, 
-					array(PDO::MYSQL_ATTR_SSL_CA => $ssl_cert_file, PDO::ATTR_PERSISTENT=>true));
-	}
-	catch (Exception $e) {
-		die ("[002] pdo connection failed. Exception: ".e.getMessage()."\n");
-	}
-	
-	$host_info = $conn->getAttribute(PDO::ATTR_CONNECTION_STATUS);
-	echo $host_info, "\n";
+        $conn = new PDO($pdo_dsn, $user, $passwd,
+                    array(PDO::MYSQL_ATTR_SSL_CA => $ssl_cert_file, PDO::ATTR_PERSISTENT=>true));
+    }
+    catch (Exception $e) {
+        die ("[002] pdo connection failed. Exception: ".e.getMessage()."\n");
+    }
 
-	if(substr($host_info, 0, strlen($host)) == $host)
-		echo "1\n";
-	else
-		echo "0\n";
-	$conn = NULL;
+    $host_info = $conn->getAttribute(PDO::ATTR_CONNECTION_STATUS);
+    echo $host_info, "\n";
+
+    if(substr($host_info, 0, strlen($host)) == $host)
+        echo "1\n";
+    else
+        echo "0\n";
+    $conn = NULL;
 }
 
 ini_set("mysqlnd_azure.enabled", 0);
 
 echo "step3: redirect disabled, non-persistent connection \n";
 {
-	echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
-	$conn = NULL;
+    echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
+    $conn = NULL;
     try {
-		$conn = new PDO($pdo_dsn, $user, $passwd, 
-					array(PDO::MYSQL_ATTR_SSL_CA => $ssl_cert_file, PDO::ATTR_PERSISTENT=>false));
-	}
-	catch (Exception $e) {
-		die ("[003] pdo connection failed. Exception: ".e.getMessage()."\n");
-	}
-	
-	$host_info = $conn->getAttribute(PDO::ATTR_CONNECTION_STATUS);
-	echo $host_info, "\n";
+        $conn = new PDO($pdo_dsn, $user, $passwd,
+                    array(PDO::MYSQL_ATTR_SSL_CA => $ssl_cert_file, PDO::ATTR_PERSISTENT=>false));
+    }
+    catch (Exception $e) {
+        die ("[003] pdo connection failed. Exception: ".e.getMessage()."\n");
+    }
 
-	if(substr($host_info, 0, strlen($host)) == $host)
-		echo "1\n";
-	else
-		echo "0\n";
-	$conn = NULL;
+    $host_info = $conn->getAttribute(PDO::ATTR_CONNECTION_STATUS);
+    echo $host_info, "\n";
+
+    if(substr($host_info, 0, strlen($host)) == $host)
+        echo "1\n";
+    else
+        echo "0\n";
+    $conn = NULL;
 }
 
 echo "step4: redirect disabled, persistent connection \n";
 {
-	echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
-	$conn = NULL;
+    echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
+    $conn = NULL;
     try {
-		$conn = new PDO($pdo_dsn, $user, $passwd, 
-					array(PDO::MYSQL_ATTR_SSL_CA => $ssl_cert_file, PDO::ATTR_PERSISTENT=>true));
-	}
-	catch (Exception $e) {
-		die ("[004] pdo connection failed. Exception: ".e.getMessage()."\n");
-	}
-	
-	$host_info = $conn->getAttribute(PDO::ATTR_CONNECTION_STATUS);
-	echo $host_info, "\n";
+        $conn = new PDO($pdo_dsn, $user, $passwd,
+                    array(PDO::MYSQL_ATTR_SSL_CA => $ssl_cert_file, PDO::ATTR_PERSISTENT=>true));
+    }
+    catch (Exception $e) {
+        die ("[004] pdo connection failed. Exception: ".e.getMessage()."\n");
+    }
 
-	if(substr($host_info, 0, strlen($host)) == $host)
-		echo "1\n";
-	else
-		echo "0\n";
-	$conn = NULL;
+    $host_info = $conn->getAttribute(PDO::ATTR_CONNECTION_STATUS);
+    echo $host_info, "\n";
+
+    if(substr($host_info, 0, strlen($host)) == $host)
+        echo "1\n";
+    else
+        echo "0\n";
+    $conn = NULL;
 }
 
 ?>

--- a/tests/server_basic_pdo_testcase.php
+++ b/tests/server_basic_pdo_testcase.php
@@ -1,0 +1,96 @@
+<?php
+require_once("connect.inc");
+
+ini_set("mysqlnd_azure.enabled", "on");
+
+echo "step1: redirect enabled, non-persistent connection \n";
+{
+	echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
+	$conn = NULL;
+    try {
+		$conn = new PDO($pdo_dsn, $user, $passwd, 
+					array(PDO::MYSQL_ATTR_SSL_CA => $ssl_cert_file, PDO::ATTR_PERSISTENT=>false));
+	}
+	catch (Exception $e) {
+		die ("[001] pdo connection failed. Exception: ".e.getMessage()."\n");
+	}
+	
+	$host_info = $conn->getAttribute(PDO::ATTR_CONNECTION_STATUS);
+	echo $host_info, "\n";
+
+	if(substr($host_info, 0, strlen($host)) == $host)
+		echo "1\n";
+	else
+		echo "0\n";
+	$conn = NULL;
+}
+
+echo "step2: redirect enabled, persistent connection \n";
+{
+	echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
+	$conn = NULL;
+    try {
+		$conn = new PDO($pdo_dsn, $user, $passwd, 
+					array(PDO::MYSQL_ATTR_SSL_CA => $ssl_cert_file, PDO::ATTR_PERSISTENT=>true));
+	}
+	catch (Exception $e) {
+		die ("[002] pdo connection failed. Exception: ".e.getMessage()."\n");
+	}
+	
+	$host_info = $conn->getAttribute(PDO::ATTR_CONNECTION_STATUS);
+	echo $host_info, "\n";
+
+	if(substr($host_info, 0, strlen($host)) == $host)
+		echo "1\n";
+	else
+		echo "0\n";
+	$conn = NULL;
+}
+
+ini_set("mysqlnd_azure.enabled", 0);
+
+echo "step3: redirect disabled, non-persistent connection \n";
+{
+	echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
+	$conn = NULL;
+    try {
+		$conn = new PDO($pdo_dsn, $user, $passwd, 
+					array(PDO::MYSQL_ATTR_SSL_CA => $ssl_cert_file, PDO::ATTR_PERSISTENT=>false));
+	}
+	catch (Exception $e) {
+		die ("[003] pdo connection failed. Exception: ".e.getMessage()."\n");
+	}
+	
+	$host_info = $conn->getAttribute(PDO::ATTR_CONNECTION_STATUS);
+	echo $host_info, "\n";
+
+	if(substr($host_info, 0, strlen($host)) == $host)
+		echo "1\n";
+	else
+		echo "0\n";
+	$conn = NULL;
+}
+
+echo "step4: redirect disabled, persistent connection \n";
+{
+	echo "mysqlnd_azure.enabled: ", ini_get("mysqlnd_azure.enabled") == true?"On":"Off", "\n";
+	$conn = NULL;
+    try {
+		$conn = new PDO($pdo_dsn, $user, $passwd, 
+					array(PDO::MYSQL_ATTR_SSL_CA => $ssl_cert_file, PDO::ATTR_PERSISTENT=>true));
+	}
+	catch (Exception $e) {
+		die ("[004] pdo connection failed. Exception: ".e.getMessage()."\n");
+	}
+	
+	$host_info = $conn->getAttribute(PDO::ATTR_CONNECTION_STATUS);
+	echo $host_info, "\n";
+
+	if(substr($host_info, 0, strlen($host)) == $host)
+		echo "1\n";
+	else
+		echo "0\n";
+	$conn = NULL;
+}
+
+?>

--- a/tests/skipif.inc
+++ b/tests/skipif.inc
@@ -4,7 +4,7 @@ if (!extension_loaded('mysqlnd')) {
 }
 
 if (!extension_loaded('mysqlnd_azure')) {
-	die('skip mysqlnd_rd extension not available');
+	die('skip mysqlnd_azure extension not available');
 }
 
 if (!extension_loaded('openssl')) {

--- a/tests/skipif.inc
+++ b/tests/skipif.inc
@@ -1,17 +1,17 @@
 <?php
 if (!extension_loaded('mysqlnd')) {
-	die('skip mysqlnd extension not available');
+    die('skip mysqlnd extension not available');
 }
 
 if (!extension_loaded('mysqlnd_azure')) {
-	die('skip mysqlnd_azure extension not available');
+    die('skip mysqlnd_azure extension not available');
 }
 
 if (!extension_loaded('openssl')) {
-	die('skip openssl extension not available');
+    die('skip openssl extension not available');
 }
 
 if (!extension_loaded('mysqli')) {
-	die('skip the tests are depended n mysqli API. mysqli extension not available');
+    die('skip the tests are depended n mysqli API. mysqli extension not available');
 }
 ?>

--- a/tests/skipif_pdo.inc
+++ b/tests/skipif_pdo.inc
@@ -1,39 +1,39 @@
 <?php
-	if (!extension_loaded('mysqlnd')) {
-		die('skip mysqlnd extension not available');
-	}
+    if (!extension_loaded('mysqlnd')) {
+        die('skip mysqlnd extension not available');
+    }
 
-	if (!extension_loaded('mysqlnd_azure')) {
-		die('skip mysqlnd_azure extension not available');
-	}
+    if (!extension_loaded('mysqlnd_azure')) {
+        die('skip mysqlnd_azure extension not available');
+    }
 
-	if (!extension_loaded('openssl')) {
-		die('skip openssl extension not available');
-	}
+    if (!extension_loaded('openssl')) {
+        die('skip openssl extension not available');
+    }
 
-	if (!extension_loaded('pdo')) {
-		die('skip the tests are depended n pdo API. pdo extension not available');
-	}
-	
-	if (!extension_loaded('pdo_mysql')) {
-		die('skip the tests are depended n pdo_mysql API. pdo_mysql extension not available');
-	}
+    if (!extension_loaded('pdo')) {
+        die('skip the tests are depended n pdo API. pdo extension not available');
+    }
 
-	include_once('connect.inc');
-	ini_set("mysqlnd_azure.enabled", "on");
-	$conn = NULL;
+    if (!extension_loaded('pdo_mysql')) {
+        die('skip the tests are depended n pdo_mysql API. pdo_mysql extension not available');
+    }
+
+    include_once('connect.inc');
+    ini_set("mysqlnd_azure.enabled", "on");
+    $conn = NULL;
     try {
-		$conn = new PDO($pdo_dsn, $user, $passwd, 
-					array(PDO::MYSQL_ATTR_SSL_CA => $ssl_cert_file, PDO::ATTR_PERSISTENT=>false));
-	}
-	catch (Exception $e) {
-		die ("skip pdo connection failed. Exception: ".$e->getMessage());
-	}
-	$host_info = $conn->getAttribute(PDO::ATTR_CONNECTION_STATUS);
+        $conn = new PDO($pdo_dsn, $user, $passwd, 
+                    array(PDO::MYSQL_ATTR_SSL_CA => $ssl_cert_file, PDO::ATTR_PERSISTENT=>false));
+    }
+    catch (Exception $e) {
+        die ("skip pdo connection failed. Exception: ".$e->getMessage());
+    }
+    $host_info = $conn->getAttribute(PDO::ATTR_CONNECTION_STATUS);
 
-	if(substr($host_info, 0, strlen($host)) == $host) {
-		die ("skip host info is same, redirection is not enabled on this server");
-	}
-	$conn = NULL;
+    if(substr($host_info, 0, strlen($host)) == $host) {
+        die ("skip host info is same, redirection is not enabled on this server");
+    }
+    $conn = NULL;
 
 ?>

--- a/tests/skipif_pdo.inc
+++ b/tests/skipif_pdo.inc
@@ -1,0 +1,39 @@
+<?php
+	if (!extension_loaded('mysqlnd')) {
+		die('skip mysqlnd extension not available');
+	}
+
+	if (!extension_loaded('mysqlnd_azure')) {
+		die('skip mysqlnd_azure extension not available');
+	}
+
+	if (!extension_loaded('openssl')) {
+		die('skip openssl extension not available');
+	}
+
+	if (!extension_loaded('pdo')) {
+		die('skip the tests are depended n pdo API. pdo extension not available');
+	}
+	
+	if (!extension_loaded('pdo_mysql')) {
+		die('skip the tests are depended n pdo_mysql API. pdo_mysql extension not available');
+	}
+
+	include_once('connect.inc');
+	ini_set("mysqlnd_azure.enabled", "on");
+	$conn = NULL;
+    try {
+		$conn = new PDO($pdo_dsn, $user, $passwd, 
+					array(PDO::MYSQL_ATTR_SSL_CA => $ssl_cert_file, PDO::ATTR_PERSISTENT=>false));
+	}
+	catch (Exception $e) {
+		die ("skip pdo connection failed. Exception: ".$e->getMessage());
+	}
+	$host_info = $conn->getAttribute(PDO::ATTR_CONNECTION_STATUS);
+
+	if(substr($host_info, 0, strlen($host)) == $host) {
+		die ("skip host info is same, redirection is not enabled on this server");
+	}
+	$conn = NULL;
+
+?>

--- a/tests/skipif_server.inc
+++ b/tests/skipif_server.inc
@@ -1,0 +1,6 @@
+<?php
+    if(false === getenv('PHP_HTTP_REMOTE_SERVER')) {
+        if (php_sapi_name() != "cli") {
+                die("skip PHP_HTTP_REMOTE_SERVER env variable is not defined");
+        }
+    }

--- a/tests/skipifconnectfailure.inc
+++ b/tests/skipifconnectfailure.inc
@@ -1,16 +1,16 @@
 <?php
-	include_once('connect.inc');
+    include_once('connect.inc');
     $link = mysqli_init();
     if(!link)
         die("skip mysqli_init failed");
 
     $ret = mysqli_real_connect($link, $host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
-	if (!$ret)
-		die(sprintf("skip Can't connect to MySQL Server with ssl - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
+    if (!$ret)
+        die(sprintf("skip Can't connect to MySQL Server with ssl - [%d] %s", mysqli_connect_errno(), mysqli_connect_error()));
 
     if(!$link->info || substr( $link->info, 0, 18 ) != "Location: mysql://") {
-	    mysqli_close($link);
-	    die("skip this mysql server does not support redirection, do not find valid redirection info");
+        mysqli_close($link);
+        die("skip this mysql server does not support redirection, do not find valid redirection info");
     }
     mysqli_close($link);
 ?>


### PR DESCRIPTION
After review with Dion, the finding is that the is_using_redirect can be safely remove it. Doing this will make the code more robust and easier to maintain.