### PR TITLE
Add AZURE_LOG() to log plugin runtime information

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,3 +213,6 @@ After this, the code directory should look like C:\php-sdk\phpdev\vc15\x64\php-s
 	$db->close();
   }
 ```
+
+### Diagnostic Log for mysqlnd\_azure
+[Configuration to get more runtime logs](doc/mysqlnd_azure_log.md)

--- a/doc/mysqlnd_azure_log.md
+++ b/doc/mysqlnd_azure_log.md
@@ -11,7 +11,7 @@ Type | String
 Accepted Value | String length <= 255, legal filename string
 Default | mysqlnd\_azure\_runtime.log
 Dynamic | NO
-Note | 1. This variable was inited at PHP Module Init (MINIT) period, and immutable at runtime. a call of `ini_set('mysqlnd_azure.logLevel', '$VAL'); ` would fail. <br> 2. Filename length cannot exceed the file system's restriction(155), otherwise system will use the default filename and throw a warning "Given logfile name too long, redirected to default: mysqlnd_azure_runtime.log"
+Note | 1. This variable was inited at PHP Module Init (MINIT) period, and immutable at runtime. a call of `ini_set('mysqlnd_azure.logLevel', '$VAL'); ` would fail. <br> 2. Filename length cannot exceed the file system's restriction(255), otherwise system will use the default filename and throw a warning "Given logfile name too long, redirected to default: mysqlnd_azure_runtime.log"
 
 
 Name | mysqlnd\_azure.logLevel

--- a/doc/mysqlnd_azure_log.md
+++ b/doc/mysqlnd_azure_log.md
@@ -11,10 +11,7 @@ Type | String
 Accepted Value | String length <= 255, legal filename string
 Default | mysqlnd\_azure\_runtime.log
 Dynamic | NO
-Note | 1. This variable was inited at PHP Module Init (MINIT) period, and immutable at runtime. a call of
-`ini\_set('mysqlnd\_azure.logLevel', '$VAL'); ` would fail. <br> 2. Filename length cannot exceed the file system's
-restriction(155), otherwise system will use the default filename and throw a warning "Given logfile name too long,
-redirected to default: mysqlnd\_azure\_runtime.log"
+Note | 1. This variable was inited at PHP Module Init (MINIT) period, and immutable at runtime. a call of `ini_set('mysqlnd_azure.logLevel', '$VAL'); ` would fail. <br> 2. Filename length cannot exceed the file system's restriction(155), otherwise system will use the default filename and throw a warning "Given logfile name too long, redirected to default: mysqlnd_azure_runtime.log"
 
 
 Name | mysqlnd\_azure.logLevel
@@ -24,7 +21,7 @@ Type | Enumeration
 Accepted Value | [ 0 \| 1 \| 2 \| 3 ]
 Default | 0 (OFF)
 Dynamic | Yes
-Note | 1. When the current `mysqlnd\_azure.logLevel > 0`, change logLevel at runtime will be logged.
+Note | 1. When the current `mysqlnd_azure.logLevel > 0`, change logLevel at runtime will be logged.
 
 ### Loglevel supported
 we support 3 level of logs for user:
@@ -40,12 +37,12 @@ we support 3 level of logs for user:
   1. any operation may cause customer see connection break (e.x. original conn/ redirected\_conn
     established failed, ... and connection fall back when mysqlnd\_azure.enableRedirection = ON)
 
-> [SYSTM], not a level for user. Logs for Azuer MySQLND Log Module, when current
-> `mysqlnd\_azure.logLevel > 0`, any operation related to log system itself will be logged.
-> For example, if someone call  `ini\_set('mysqlnd\_azure.logLevel', '2');` at runtime, there
+> [SYSTM] maked log rows for Azure mysqlnd Log Module itself, when current
+> `mysqlnd_azure.logLevel > 0`, any operation related to log system itself will be logged.
+> For example, if someone call  `ini_set('mysqlnd_azure.logLevel', '2');` at runtime, there
 > may appear a log like 
 > ```
-> 2020-03-27 09:09:05 [SYSTM] mysqlnd\_azure.logLevel changed: 3 -> 2
+> 2020-03-27 09:09:05 [SYSTM] mysqlnd_azure.logLevel changed: 3 -> 2
 > ```
 
 
@@ -62,10 +59,10 @@ we support 3 level of logs for user:
 > You can add to section [mysqlnd\_azure] in file `php.ini`
 
 ```
-[mysqlnd\_azure]
-mysqlnd\_azure.enableRedirect = 2
-mysqlnd\_azure.logfilePath = "test.log"
-mysqlnd\_azure.logLevel = 3
+[mysqlnd_azure]
+mysqlnd_azure.enableRedirect = 2
+mysqlnd_azure.logfilePath = "test.log"
+mysqlnd_azure.logLevel = 3
 ```
 
 ### phpinfo() / php -i
@@ -74,9 +71,9 @@ After successfully configured, try `php -i`, there will be var:val pairs listed 
 mysqlnd\_azure section, like:
 
 ```
-mysqlnd\_azure
+mysqlnd_azure
 
-mysqlnd\_azure => enableRedirect
+mysqlnd_azure => enableRedirect
 enableRedirect => preferred
 logfilePath => santotest.log
 logLevel => 3

--- a/doc/mysqlnd_azure_log.md
+++ b/doc/mysqlnd_azure_log.md
@@ -1,0 +1,83 @@
+# Diagnostic Log Configuration
+
+Log down some running information of mysqlnd\_azure to a local file.
+
+## Configuration Oprions
+
+Name | mysqlnd\_azure.logfilePath
+:----- | :------
+Comment | Filename that you want your log writes to.
+Type | String
+Accepted Value | String length <= 255, legal filename string
+Default | mysqlnd\_azure\_runtime.log
+Dynamic | NO
+Note | 1. This variable was inited at PHP Module Init (MINIT) period, and immutable at runtime. a call of
+`ini\_set('mysqlnd\_azure.logLevel', '$VAL'); ` would fail. <br> 2. Filename length cannot exceed the file system's
+restriction(155), otherwise system will use the default filename and throw a warning "Given logfile name too long,
+redirected to default: mysqlnd\_azure\_runtime.log"
+
+
+Name | mysqlnd\_azure.logLevel
+:----- | :------
+Comment | The verbose level of log we generate.
+Type | Enumeration
+Accepted Value | [ 0 \| 1 \| 2 \| 3 ]
+Default | 0 (OFF)
+Dynamic | Yes
+Note | 1. When the current `mysqlnd\_azure.logLevel > 0`, change logLevel at runtime will be logged.
+
+### Loglevel supported
+we support 3 level of logs for user:
+- [DEBUG]:
+  1. source code path(inside which function);
+  2. connection information(except password);
+  3. verbose running status (e.g. customer given redirected server information directly... )
+- [INFO]:
+  1. connection fallback when mysqlnd\_azure.enableRedirection=preferred with details (cannot get redirection
+      info from OK packet/ try connect using redirect information failed , ...);
+  2. cache operations
+- [ERROR]:
+  1. any operation may cause customer see connection break (e.x. original conn/ redirected\_conn
+    established failed, ... and connection fall back when mysqlnd\_azure.enableRedirection = ON)
+
+> [SYSTM], not a level for user. Logs for Azuer MySQLND Log Module, when current
+> `mysqlnd\_azure.logLevel > 0`, any operation related to log system itself will be logged.
+> For example, if someone call  `ini\_set('mysqlnd\_azure.logLevel', '2');` at runtime, there
+> may appear a log like 
+> ```
+> 2020-03-27 09:09:05 [SYSTM] mysqlnd\_azure.logLevel changed: 3 -> 2
+> ```
+
+
+> note: OOM not included this version.
+
+#### Level value relationship to level logged
+- 0: No log written
+- 1: [SYSTM] + [ERROR]
+- 2: [SYSTM] + [ERROR] + [INFO]
+- 3: [SYSTM] + [ERROR] + [INFO] + [DEBUG]
+
+
+## Usage Example
+> You can add to section [mysqlnd\_azure] in file `php.ini`
+
+```
+[mysqlnd\_azure]
+mysqlnd\_azure.enableRedirect = 2
+mysqlnd\_azure.logfilePath = "test.log"
+mysqlnd\_azure.logLevel = 3
+```
+
+### phpinfo() / php -i
+
+After successfully configured, try `php -i`, there will be var:val pairs listed below
+mysqlnd\_azure section, like:
+
+```
+mysqlnd\_azure
+
+mysqlnd\_azure => enableRedirect
+enableRedirect => preferred
+logfilePath => santotest.log
+logLevel => 3
+```

--- a/mysqlnd_azure.c
+++ b/mysqlnd_azure.c
@@ -711,24 +711,6 @@ MYSQLND_METHOD(mysqlnd_azure, connect)(MYSQLND * conn_handle,
 }
 /* }}} */
 
-
-/* {{{ mysqlnd_azure_minit_register_hooks */
-void mysqlnd_azure_minit_register_hooks()
-{
-    mysqlnd_azure_plugin_id = mysqlnd_plugin_register();
-
-    conn_m = mysqlnd_conn_get_methods();
-    memcpy(&org_conn_m, conn_m, sizeof(struct st_mysqlnd_conn_methods));
-
-    conn_d_m = mysqlnd_conn_data_get_methods();
-    memcpy(&org_conn_d_m, conn_d_m, sizeof(struct st_mysqlnd_conn_data_methods));
-
-    conn_m->connect = MYSQLND_METHOD(mysqlnd_azure, connect);
-    conn_d_m->connect = MYSQLND_METHOD(mysqlnd_azure_data, connect);
-}
-
-/* }}} */
-
 /* {{{ mysqlnd_azure_apply_resources, do resource apply works when module init*/
 int mysqlnd_azure_apply_resources() {
   if (MYSQLND_AZURE_G(logLevel) > 0) {
@@ -749,4 +731,21 @@ int mysqlnd_azure_release_resources() {
   }
   return 0;
 }
+/* }}} */
+
+/* {{{ mysqlnd_azure_minit_register_hooks */
+void mysqlnd_azure_minit_register_hooks()
+{
+    mysqlnd_azure_plugin_id = mysqlnd_plugin_register();
+
+    conn_m = mysqlnd_conn_get_methods();
+    memcpy(&org_conn_m, conn_m, sizeof(struct st_mysqlnd_conn_methods));
+
+    conn_d_m = mysqlnd_conn_data_get_methods();
+    memcpy(&org_conn_d_m, conn_d_m, sizeof(struct st_mysqlnd_conn_data_methods));
+
+    conn_m->connect = MYSQLND_METHOD(mysqlnd_azure, connect);
+    conn_d_m->connect = MYSQLND_METHOD(mysqlnd_azure_data, connect);
+}
+
 /* }}} */

--- a/mysqlnd_azure.c
+++ b/mysqlnd_azure.c
@@ -726,12 +726,12 @@ int mysqlnd_azure_apply_resources() {
     OPEN_LOGFILE(logfilePath);
 
     if (logflag) {
-      php_error_docref(NULL, E_WARNING, "Logfile string length exceeds 255, redirected to mysqlnd_azure_runtime.log");
+      php_error_docref(NULL, E_WARNING, "[mysqlnd_azure] Logfile string length exceeds 255, redirected to mysqlnd_azure_runtime.log");
       AZURE_LOG_SYS("Given logfile name too long, redirected to default: mysqlnd_azure_runtime.log");
     }
 
     if (logfile == NULL) {
-      php_error_docref(NULL, E_WARNING, "Unable to open log file: %s", logfilePath);
+      php_error_docref(NULL, E_WARNING, "[mysqlnd_azure] Unable to open log file: %s", logfilePath);
       return 1;
     }
   }

--- a/mysqlnd_azure.c
+++ b/mysqlnd_azure.c
@@ -714,10 +714,26 @@ MYSQLND_METHOD(mysqlnd_azure, connect)(MYSQLND * conn_handle,
 /* {{{ mysqlnd_azure_apply_resources, do resource apply works when module init*/
 int mysqlnd_azure_apply_resources() {
   if (MYSQLND_AZURE_G(logLevel) > 0) {
-    char *logfilePath = ZSTR_VAL(MYSQLND_AZURE_G(logfilePath));
+    char *logfilePath = NULL;
+    int logflag = 0;
+    if (ZSTR_LEN(MYSQLND_AZURE_G(logfilePath)) > 155) {
+      logflag = 1;
+      logfilePath = "mysqlnd_azure_runtime.log";
+    } else {
+      logfilePath = ZSTR_VAL(MYSQLND_AZURE_G(logfilePath));
+    }
+
     OPEN_LOGFILE(logfilePath);
 
-    if (logfile == NULL) return 1;
+    if (logflag) {
+      php_error_docref(NULL, E_WARNING, "Logfile string length exceeds 255, redirected to mysqlnd_azure_runtime.log");
+      AZURE_LOG_SYS("Given logfile name too long, redirected to default: mysqlnd_azure_runtime.log");
+    }
+
+    if (logfile == NULL) {
+      php_error_docref(NULL, E_WARNING, "Unable to open log file: %s", logfilePath);
+      return 1;
+    }
   }
   return 0;
 }

--- a/mysqlnd_azure.c
+++ b/mysqlnd_azure.c
@@ -29,16 +29,23 @@
 #include "ext/mysqlnd/mysqlnd_statistics.h"
 #include "ext/mysqlnd/mysqlnd_connection.h"
 
+#include "utils.h"
+
 unsigned int mysqlnd_azure_plugin_id;
 struct st_mysqlnd_conn_data_methods org_conn_d_m;
 struct st_mysqlnd_conn_data_methods* conn_d_m;
 struct st_mysqlnd_conn_methods org_conn_m;
 struct st_mysqlnd_conn_methods* conn_m;
 
+FILE *logfile;
+
 /* {{{ set_redirect_client_options */
 static enum_func_status
 set_redirect_client_options(MYSQLND_CONN_DATA * const conn, MYSQLND_CONN_DATA * const redirectConn)
 {
+  if (MYSQLND_AZURE_G(logLevel) > 2) {
+    AZURE_LOG("DEBUG", "mysqlnd_azure.c: set_redirect_client_options()");
+  }
     //TODO: the fields copies here are from list that is handled in mysqlnd_conn_data::set_client_option, may not compelete, and may need update when mysqlnd_conn_data::set_client_option updates
     DBG_ENTER("mysqlnd_azure_data::set_redirect_client_options Copy client options for redirection connection");
     enum_func_status ret = FAIL;
@@ -168,6 +175,9 @@ get_redirect_info(const MYSQLND_CONN_DATA * const conn, char* redirect_host, cha
     * the minimal len is 28 bytes
     */
 
+  if (MYSQLND_AZURE_G(logLevel) > 2) {
+    AZURE_LOG("DEBUG", "mysqlnd_azure.c: get_redirect_info()");
+  }
     const char * msg_header = "Location: mysql://";
     int msg_header_len = strlen(msg_header);
 
@@ -242,6 +252,9 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
                         unsigned int mysql_flags
                     )
 {
+  if (MYSQLND_AZURE_G(logLevel) > 2) {
+    AZURE_LOG("DBEUG", "mysqlnd_azure.c: mysqlnd_azure_data::connect()");
+  }
     MYSQLND_CONN_DATA * conn = *pconn;
 
     const size_t this_func = STRUCT_OFFSET(MYSQLND_CLASS_METHODS_TYPE(mysqlnd_conn_data), connect);
@@ -267,6 +280,12 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
     DBG_INF_FMT("host=%s user=%s db=%s port=%u flags=%u persistent=%u state=%u",
                 hostname.s?hostname.s:"", username.s?username.s:"", database.s?database.s:"", port, mysql_flags,
                 conn? conn->persistent:0, conn? (int)GET_CONNECTION_STATE(&conn->state):-1);
+
+    if (MYSQLND_AZURE_G(logLevel) > 2) {
+      AZURE_LOG("DEBUG", "Connection Information: host=%s user=%s db=%s port=%u flags=%u persistent=%u state=%u",
+          hostname.s?hostname.s:"", username.s?username.s:"", database.s?database.s:"", port, mysql_flags,
+          conn? conn->persistent:0, conn? (int)GET_CONNECTION_STATE(&conn->state):-1);
+    }
 
     if (GET_CONNECTION_STATE(&conn->state) > CONN_ALLOCED) {
         DBG_INF("Connecting on a connected handle.");
@@ -325,6 +344,9 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
     {
         const MYSQLND_CSTRING scheme = { transport.s, transport.l };
         if (FAIL == conn->m->connect_handshake(conn, &scheme, &username, &password, &database, mysql_flags)) {
+          if (MYSQLND_AZURE_G(logLevel) > 0) {
+            AZURE_LOG("ERROR", "Connection cannot established with given information, please check the server availability, or your parameters given");
+          }
             goto err;
         }
     }
@@ -332,6 +354,9 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
     /*start of Azure Redirection logic*/
     //Redirect before run init_command
     {
+      if (MYSQLND_AZURE_G(logLevel) > 2) {
+        AZURE_LOG("DEBUG", "Classical connection OK, try to get REDIRECTION information");
+      }
         SET_CONNECTION_STATE(&conn->state, CONN_READY); //set ready status so the connection can be closed correctly later if redirect succeeds
 
         DBG_ENTER("[redirect]: mysqlnd_azure_data::connect::redirect");
@@ -340,13 +365,22 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
         unsigned int ui_redirect_port = 0;
         zend_bool serverSupportRedirect = get_redirect_info(conn, redirect_host, redirect_user, &ui_redirect_port);
         if (!serverSupportRedirect) {
+          if (MYSQLND_AZURE_G(logLevel) > 0) {
+            AZURE_LOG("ERROR", "Failed to get REDIRECTION information from OK Packet, please check whether your MySQL server support redirect.");
+          }
             DBG_ENTER("[redirect]: Server does not support redirection.");
             if(MYSQLND_AZURE_G(enableRedirect) == REDIRECT_ON) {
                 //REDIRECT_ON, if redirection is not supported, abort the original connection and return error
                 conn->m->send_close(conn);
+                if (MYSQLND_AZURE_G(logLevel) > 0) {
+                  AZURE_LOG("ERROR", "mysqlnd_azure.Redirection: ON, MySQL server not support REDERECTION, connection failed");
+                }
                 SET_CLIENT_ERROR(conn->error_info, MYSQLND_AZURE_ENFORCE_REDIRECT_ERROR_NO, UNKNOWN_SQLSTATE, "Connection aborted because redirection is not enabled on the MySQL server or the network package doesn't meet meet redirection protocol.");
                 goto err;
             } else {
+              if (MYSQLND_AZURE_G(logLevel) > 1) {
+                AZURE_LOG("INFO ", "mysqlnd_zaure.Redirection: PREFERRED, MySQL server not support REDIRECTION, conn falls back to classical one.");
+              }
                 //REDIRECT_PREFERRED, do nothing else for redirection, just use the previous connection
                 goto after_conn;
             }
@@ -354,9 +388,15 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
 
         //Get here means serverSupportRedirect
 
+        if (MYSQLND_AZURE_G(logLevel) > 2) {
+          AZURE_LOG("DEBUG", "Successfully get redirection information, try to connect with redirection connection");
+        }
         //Already use redirected connection, or the connection string is a redirected one
         if (strcmp(redirect_host, hostname.s) == 0 && strcmp(redirect_user, username.s) == 0 && ui_redirect_port == port) {
             DBG_ENTER("[redirect]: Is using redirection, or redirection info are equal to origin, no need to redirect");
+            if (MYSQLND_AZURE_G(logLevel) > 2) {
+              AZURE_LOG("DEBUG", "Given information if same as redirected connection, do nothing and just connect it.");
+            }
             goto after_conn;
         }
 
@@ -366,6 +406,9 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
             enum_func_status ret = FAIL;
             MYSQLND* redirect_conneHandle = mysqlnd_init(MYSQLND_CLIENT_KNOWS_RSET_COPY_DATA, conn->persistent); //init MYSQLND but only need only MYSQLND_CONN_DATA here
             if(!redirect_conneHandle) {
+              if (MYSQLND_AZURE_G(logLevel) > 0) {
+                AZURE_LOG("DEBUG", "Cannot connet with refirection information, redirect connection handshake failed");
+              }
                 DBG_ENTER("[redirect]: init redirect_conneHandle failed");
                 if(MYSQLND_AZURE_G(enableRedirect) == REDIRECT_ON) {
                     //REDIRECT_ON, abort the original connection and return error
@@ -373,6 +416,9 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
                     SET_CLIENT_ERROR(conn->error_info, MYSQLND_AZURE_ENFORCE_REDIRECT_ERROR_NO, UNKNOWN_SQLSTATE, "Connection aborted because init redirection failed.");
                     goto err;
                 } else {
+                  if (MYSQLND_AZURE_G(logLevel) > 1) {
+                    AZURE_LOG("INFO ", "Redirection connection failed, mysqlnd_azure.enableRedirect = PREFERRED, so fall back to classical connection.");
+                  }
                     //REDIRECT_PREFERRED, do nothing else for redirection, just use the previous connection
                     goto after_conn;
                 }
@@ -387,6 +433,9 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
 
             //init redirect_conn options failed, just use the proxy connection
             if (ret == FAIL) {
+              if (MYSQLND_AZURE_G(logLevel) > 0) {
+                AZURE_LOG("ERROR", "Set redirection information to redirect conn failed.");
+              }
                 DBG_ENTER("[redirect]: init redirection option failed. ");
                 redirect_conn->m->dtor(redirect_conn); //release created resource
                 redirect_conn = NULL;
@@ -397,6 +446,9 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
                     SET_CLIENT_ERROR(conn->error_info, MYSQLND_AZURE_ENFORCE_REDIRECT_ERROR_NO, UNKNOWN_SQLSTATE, "Connection aborted because init redirection failed.");
                     goto err;
                 } else {
+                  if (MYSQLND_AZURE_G(logLevel) > 1) {
+                    AZURE_LOG("INFO ", "Init redirect conn failed, mysqlnd_azure.enableRedirect = PREFERRED, so fall back to classical connection.");
+                  }
                     //REDIRECT_PREFERRED, do nothing else for redirection, just use the previous connection
                     goto after_conn;
                 }
@@ -413,6 +465,10 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
             enum_func_status redirectState = redirect_conn->m->connect_handshake(redirect_conn, &redirect_scheme, &redirect_username, &password, &database, mysql_flags);
 
             if (redirectState == PASS) { //handshake with redirect_conn succeeded, replace original connection info with redirect_conn and add the redirect info into cache table
+
+              if (MYSQLND_AZURE_G(logLevel) > 2) {
+                AZURE_LOG("DEBUG", "Redirect conntion established.");
+              }
                 DBG_ENTER("[redirect]: mysql redirect handshake succeeded.");
 
                 //add the redirect info into cache table
@@ -439,6 +495,9 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
                 redirect_transport.s = NULL;
 
             } else { //redirect failed. if REDIRECT_ON, also abort the original conn, if REDIRECT_PREFERRED, use original connection
+              if (MYSQLND_AZURE_G(logLevel) > 0) {
+                AZURE_LOG("ERROR", "Redirection connection failed(handshake)");
+              }
                 DBG_ENTER("[redirect]: mysql redirect handshake fails");
                 //need free in both cases
                 if (redirect_transport.s) {
@@ -447,6 +506,9 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
                 }
 
                 if (MYSQLND_AZURE_G(enableRedirect) == REDIRECT_PREFERRED) {
+                  if (MYSQLND_AZURE_G(logLevel > 1)) {
+                    AZURE_LOG("INFO ", "Redirection conn connect failed, mysqlnd_azure.enableRedirect = PREFERRED, fall back to classical connection.");
+                  }
                     //free object and use original connection
                     redirect_conn->m->dtor(redirect_conn);
                     goto after_conn;
@@ -471,6 +533,9 @@ MYSQLND_METHOD(mysqlnd_azure_data, connect)(MYSQLND_CONN_DATA ** pconn,
 
 after_conn:
     {
+      if (MYSQLND_AZURE_G(logLevel) > 2) {
+        AZURE_LOG("DEBUG", "Prepare the context of new connection");
+      }
         SET_CONNECTION_STATE(&conn->state, CONN_READY);
 
         if (saved_compression) {
@@ -610,6 +675,15 @@ MYSQLND_METHOD(mysqlnd_azure, connect)(MYSQLND * conn_handle,
                         const MYSQLND_CSTRING socket_or_pipe,
                         unsigned int mysql_flags)
 {
+  int logLevel = MYSQLND_AZURE_G(logLevel);
+  if (logLevel > 0) {
+    char *logfilePath = ZSTR_VAL(MYSQLND_AZURE_G(logfilePath));
+    OPEN_LOGFILE(logfilePath);
+  }
+
+  if (logLevel > 2) {
+    AZURE_LOG("DEBUG", "mysqlnd_azure.c: mysqlnd_azure::connect()");
+  }
     const size_t this_func = STRUCT_OFFSET(MYSQLND_CLASS_METHODS_TYPE(mysqlnd_conn_data), connect);
     enum_func_status ret = FAIL;
     MYSQLND_CONN_DATA ** pconn = &conn_handle->data;
@@ -624,6 +698,9 @@ MYSQLND_METHOD(mysqlnd_azure, connect)(MYSQLND * conn_handle,
 
         if (MYSQLND_AZURE_G(enableRedirect) == REDIRECT_OFF) {
             DBG_ENTER("mysqlnd_azure::connect redirect disabled");
+            if (logLevel > 2) {
+              AZURE_LOG("DEBUG", "mysqlnd_azure.enableRedirect: OFF");
+            }
             ret = org_conn_d_m.connect(*pconn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);
         }
         else {
@@ -634,12 +711,24 @@ MYSQLND_METHOD(mysqlnd_azure, connect)(MYSQLND * conn_handle,
             if (!(temp_flags & CLIENT_SSL)) {
                 //REDIRECT_ON, no ssl, return error
                 if((MYSQLND_AZURE_G(enableRedirect) == REDIRECT_ON)) {
+                  if (logLevel > 2) {
+                    AZURE_LOG("DEBUG", "mysqlnd_azure.enableRedirect: ON");
+                  }
+                  if (logLevel > 0) {
+                    AZURE_LOG("ERROR", "SSL not enabled when mysqlnd_azure.enableRedirect if ON");
+                  }
                     SET_CLIENT_ERROR((*pconn)->error_info, MYSQLND_AZURE_ENFORCE_REDIRECT_ERROR_NO, UNKNOWN_SQLSTATE, "mysqlnd_azure.enableRedirect is on, but SSL option is not set in connection string. Redirection is only possible with SSL.");
                     (*pconn)->m->local_tx_end(*pconn, this_func, FAIL);
                     (*pconn)->m->free_contents(*pconn);
                     return FAIL;
                 }
                 else { //REDIRECT_PREFERRED, no ssl, do not redirect
+                  if (logLevel > 2) {
+                    AZURE_LOG("DEBUG", "mysqlnd_azure.enableRedirect: PREFERRD");
+                  }
+                  if (logLevel > 1) {
+                    AZURE_LOG("INFO ", "SSL not enabled, and mysqlnd_zaure.enableRedirect if PREFERRED, connection will go through gateway.");
+                  }
                     ret = org_conn_d_m.connect(*pconn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);
                 }
             }
@@ -654,6 +743,9 @@ MYSQLND_METHOD(mysqlnd_azure, connect)(MYSQLND * conn_handle,
 
                     ret = (*pconn)->m->connect(pconn, redirect_host, redirect_user, password, database, redirect_info->redirect_port, socket_or_pipe, mysql_flags);
                     if (ret == FAIL) {
+                      if (logLevel > 1) {
+                        AZURE_LOG("INFO ", "Redirect cache miss");
+                      }
                         //remove invalid cache
                         mysqlnd_azure_remove_redirect_cache(username.s, hostname.s, port);
 
@@ -661,6 +753,9 @@ MYSQLND_METHOD(mysqlnd_azure, connect)(MYSQLND * conn_handle,
                     }
                 }
                 else {
+                  if (logLevel > 1) {
+                    AZURE_LOG("INFO ", "No cache found");
+                  }
                     ret = (*pconn)->m->connect(pconn, hostname, username, password, database, port, socket_or_pipe, mysql_flags);
                 }
 
@@ -670,6 +765,7 @@ MYSQLND_METHOD(mysqlnd_azure, connect)(MYSQLND * conn_handle,
         (*pconn)->m->local_tx_end(*pconn, this_func, FAIL);
 
     }
+    CLOSE_LOGFILE();
     DBG_RETURN(ret);
 }
 /* }}} */

--- a/mysqlnd_azure.h
+++ b/mysqlnd_azure.h
@@ -40,6 +40,9 @@ typedef struct st_mysqlnd_azure_redirect_info {
 
 void mysqlnd_azure_minit_register_hooks();
 
+int mysqlnd_azure_apply_resources();
+int mysqlnd_azure_release_resources();
+
 enum_func_status mysqlnd_azure_add_redirect_cache(const char* user, const char* host, int port, const char* redirect_user, const char* redirect_host, int redirect_port);
 enum_func_status mysqlnd_azure_remove_redirect_cache(const char* user, const char* host, int port);
 MYSQLND_AZURE_REDIRECT_INFO* mysqlnd_azure_find_redirect_cache(const char* user, const char* host, int port);

--- a/package.xml
+++ b/package.xml
@@ -45,6 +45,7 @@
    <file md5sum="81379d753b8268922e3e3dd8c11c803c" name="redirect_cache.c" role="src" />
    <file md5sum="f6ce2d3ccfaa1d8e53196f9df9043b35" name="mysqlnd_azure.h" role="src" />
    <file md5sum="207e117afe26f28a75d83776e88d7ee0" name="php_mysqlnd_azure.h" role="src" />
+   <file md5sum="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" name="utils.h" role="src" />
    <file md5sum="1d60dd2a72d2d9a325e68070b7fd0fbf" name="tests/mysqli_azure_redirection_on.phpt" role="test" />
    <file md5sum="a678a17b08f337292c0471b26be405f5" name="tests/mysqli_azure_redirection_off.phpt" role="test" />
    <file md5sum="a678a17b08f337292c0471b26be405f5" name="tests/mysqli_azure_redirection_preferred.phpt" role="test" />

--- a/php_mysqlnd_azure.c
+++ b/php_mysqlnd_azure.c
@@ -52,11 +52,31 @@ static ZEND_INI_MH(OnUpdateEnableRedirect)
     return SUCCESS;
 
 }
+
+static ZEND_INI_MH(OnUpdateEnableLogfile) {
+  MYSQLND_AZURE_G(logfilePath) = new_value;
+  return SUCCESS;
+}
+
+static ZEND_INI_MH(OnUpdateEnableLogLevel) {
+  if (STRING_EQUALS(new_value, "3")) {
+    MYSQLND_AZURE_G(logLevel) = 3;
+  } else if (STRING_EQUALS(new_value, "2")) {
+    MYSQLND_AZURE_G(logLevel) = 2;
+  } else if (STRING_EQUALS(new_value, "1")) {
+    MYSQLND_AZURE_G(logLevel) = 1;
+  } else {
+    MYSQLND_AZURE_G(logLevel) = 0;
+  }
+  return SUCCESS;
+}
 /* }}} */
 
 /* {{{ PHP_INI */
 PHP_INI_BEGIN()
 STD_PHP_INI_ENTRY("mysqlnd_azure.enableRedirect", "preferred", PHP_INI_ALL, OnUpdateEnableRedirect, enableRedirect, zend_mysqlnd_azure_globals, mysqlnd_azure_globals)
+STD_PHP_INI_ENTRY("mysqlnd_azure.logfilePath", "mysqlnd_azure_runtime.log", PHP_INI_ALL, OnUpdateEnableLogfile, logfilePath, zend_mysqlnd_azure_globals, mysqlnd_azure_globals)
+STD_PHP_INI_ENTRY("mysqlnd_azure.logLevel", "0", PHP_INI_ALL, OnUpdateEnableLogLevel, logLevel, zend_mysqlnd_azure_globals, mysqlnd_azure_globals)
 PHP_INI_END()
 /* }}} */
 
@@ -68,6 +88,8 @@ static PHP_GINIT_FUNCTION(mysqlnd_azure)
 #endif
     mysqlnd_azure_globals->enableRedirect = REDIRECT_PREFERRED;
     mysqlnd_azure_globals->redirectCache = NULL;
+    mysqlnd_azure_globals->logfilePath = "mysqlnd_azure_runtime.log";
+    mysqlnd_azure_globals->logLevel = 0;
 }
 /* }}} */
 

--- a/php_mysqlnd_azure.h
+++ b/php_mysqlnd_azure.h
@@ -43,8 +43,8 @@ ZEND_BEGIN_MODULE_GLOBALS(mysqlnd_azure)
     mysqlnd_azure_redirect_mode     enableRedirect;
     HashTable*                      redirectCache;
     // TODO: restrict string length
-    zend_string* logfilePath;
-    int logLevel;
+    zend_string*                    logfilePath;
+    int                             logLevel;
 ZEND_END_MODULE_GLOBALS(mysqlnd_azure)
 
 PHPAPI ZEND_EXTERN_MODULE_GLOBALS(mysqlnd_azure)

--- a/php_mysqlnd_azure.h
+++ b/php_mysqlnd_azure.h
@@ -42,6 +42,9 @@ typedef enum _mysqlnd_azure_redirect_mode {
 ZEND_BEGIN_MODULE_GLOBALS(mysqlnd_azure)
     mysqlnd_azure_redirect_mode     enableRedirect;
     HashTable*                      redirectCache;
+    // TODO: restrict string length
+    zend_string* logfilePath;
+    int logLevel;
 ZEND_END_MODULE_GLOBALS(mysqlnd_azure)
 
 PHPAPI ZEND_EXTERN_MODULE_GLOBALS(mysqlnd_azure)

--- a/utils.h
+++ b/utils.h
@@ -5,32 +5,40 @@
 #include <time.h>
 #include <stdlib.h>
 
+#include "php_mysqlnd_azure.h"
+
 extern FILE *logfile;
 #define TIME_FORMAT "%Y-%m-%d %H:%M:%S"
 
-#define OPEN_LOGFILE(filename) \
-  do {\
-    if (filename != NULL) {\
-      logfile = fopen(filename, "a"); \
-    }\
+// Azure Log Levels, 1(ERROR), 2(INFO), 3(DEBUG)
+#define ALOGERR  1
+#define ALOGINFO 2
+#define ALOGDBG  3
+
+#define OPEN_LOGFILE(filename)                                                \
+  do {                                                                        \
+    if (filename != NULL) {                                                   \
+      logfile = fopen(filename, "a");                                         \
+    }                                                                         \
   } while (0)
 
-#define CLOSE_LOGFILE() \
-  do {\
-    if (logfile != NULL) { \
-      fclose(logfile);\
+#define CLOSE_LOGFILE()                                                       \
+  do {                                                                        \
+    if (logfile != NULL) {                                                    \
+      fclose(logfile);                                                        \
     } } while (0)
 
-#define AZURE_LOG(level, format, ...) \
-  do { \
-    if (logfile != NULL) { \
-      time_t now = time(NULL); \
-      char timestr[20];\
-      strftime(timestr, 20, TIME_FORMAT, localtime(&now)); \
-      fprintf(logfile, " %s [" level "] " format "\n", timestr, \
-                              ## __VA_ARGS__);        \
-      fflush(logfile); \
-    } \
+#define AZURE_LOG(level, format, ...)                                         \
+  do {                                                                        \
+    if (logfile != NULL && level <= MYSQLND_AZURE_G(logLevel)) {              \
+      time_t now = time(NULL);                                                \
+      char timestr[20];                                                       \
+      char *levelstr = level == 1 ? "ERROR" : level == 2 ? "INFO " : "DEBUG"; \
+      strftime(timestr, 20, TIME_FORMAT, localtime(&now));                    \
+      fprintf(logfile, " %s [%s] " format "\n", timestr, levelstr,            \
+                              ## __VA_ARGS__);                                \
+      fflush(logfile);                                                        \
+    }                                                                         \
   } while (0)
 
 #endif // UTILS_H

--- a/utils.h
+++ b/utils.h
@@ -41,4 +41,17 @@ extern FILE *logfile;
     }                                                                         \
   } while (0)
 
+#define AZURE_LOG_SYS(format, ...)                                            \
+  do {                                                                        \
+    if (MYSQLND_AZURE_G(logLevel) != 0 && logfile != NULL) {                  \
+      time_t now = time(NULL);                                                \
+      char timestr[20];                                                       \
+      strftime(timestr, 20, TIME_FORMAT, localtime(&now));                    \
+      fprintf(logfile, " %s [SYSTM] " format "\n", timestr,                   \
+                              ## __VA_ARGS__);                                \
+      fflush(logfile);                                                        \
+    }                                                                         \
+  } while (0)
+
+
 #endif // UTILS_H

--- a/utils.h
+++ b/utils.h
@@ -1,0 +1,36 @@
+#ifndef _UTILS_H
+#define _UTILS_H
+
+#include <stdio.h>
+#include <time.h>
+#include <stdlib.h>
+
+extern FILE *logfile;
+#define TIME_FORMAT "%Y-%m-%d %H:%M:%S"
+
+#define OPEN_LOGFILE(filename) \
+  do {\
+    if (filename != NULL) {\
+      logfile = fopen(filename, "a"); \
+    }\
+  } while (0)
+
+#define CLOSE_LOGFILE() \
+  do {\
+    if (logfile != NULL) { \
+      fclose(logfile);\
+    } } while (0)
+
+#define AZURE_LOG(level, format, ...) \
+  do { \
+    if (logfile != NULL) { \
+      time_t now = time(NULL); \
+      char timestr[20];\
+      strftime(timestr, 20, TIME_FORMAT, localtime(&now)); \
+      fprintf(logfile, " %s [" level "] " format "\n", timestr, \
+                              ## __VA_ARGS__);        \
+      fflush(logfile); \
+    } \
+  } while (0)
+
+#endif // UTILS_H


### PR DESCRIPTION
# Logs  for mysqlnd_azure plugin

This patch is added for print some running information of mysqlnd_azure to a local file.
Current status: Under developing.

## New Added Configuration
### `mysqlnd_azure.logfilePath`

Name | mysqlnd\_azure.logfilePath
:----- | :------
Comment | Filename that you want your log writes to.
Type | String
Accepted Value | String length <= 255, legal filename string
Default | mysqlnd\_azure\_runtime.log
Dynamic | NO
Note | 1. This variable was inited at PHP Module Init (MINIT) period, and immutable at runtime. a call of `ini_set('mysqlnd_azure.logLevel', '$VAL'); ` would fail. <br> 2. Filename length cannot exceed the file system's restriction(255), otherwise system will use the default filename and throw a warning "Given logfile name too long, redirected to default: mysqlnd_azure_runtime.log"

### `mysqlnd_azure.logLevel`

Name | mysqlnd\_azure.logLevel
:----- | :------
Comment | The verbose level of log we generate.
Type | Enumeration
Accepted Value | [ 0 \| 1 \| 2 \| 3 ]
Default | 0 (OFF)
Dynamic | Yes
Note | 1. When the current `mysqlnd_azure.logLevel > 0`, change logLevel at runtime will be logged.


#### Loglevel supported
we support 3 level of logs for user:
- [DEBUG]:
  1. source code path(inside which function);
  2. connection information(except password);
  3. verbose running status (e.g. customer given redirected server information directly... )
- [INFO]:
  1. connection fallback when mysqlnd\_azure.enableRedirection=preferred with details (cannot get redirection
      info from OK packet/ try connect using redirect information failed , ...);
  2. cache operations
- [ERROR]:
  1. any operation may cause customer see connection break (e.x. original conn/ redirected\_conn
    established failed, ... and connection fall back when mysqlnd\_azure.enableRedirection = ON)


> [SYSTM] maked log rows for Azure mysqlnd Log Module itself, when current
> `mysqlnd_azure.logLevel > 0`, any operation related to log system itself will be logged.
> For example, if someone call  `ini_set('mysqlnd_azure.logLevel', '2');` at runtime, there
> may appear a log like 
> ```
> 2020-03-27 09:09:05 [SYSTM] mysqlnd_azure.logLevel changed: 3 -> 2
> ```

#### Level value relationship to level logged
- 0: No log written
- 1: [SYSTM] + [ERROR]
- 2: [SYSTM] + [ERROR] + [INFO]
- 3: [SYSTM] + [ERROR] + [INFO] + [DEBUG]


### Configuration Example:

> You can add to section [mysqlnd\_azure] in file `php.ini`

```
[mysqlnd_azure]
mysqlnd_azure.enableRedirect = 2
mysqlnd_azure.logfilePath = "test.log"
mysqlnd_azure.logLevel = 3
```

### phpinfo() / php -i

After successfully configured, try `php -i`, there will be var:val pairs listed below
mysqlnd\_azure section, like:

```
mysqlnd_azure

mysqlnd_azure => enableRedirect
enableRedirect => preferred
logfilePath => santotest.log
logLevel => 3
```

## What the logs would be (example)
After turned on the option mentioned before, you will see something like :
```
2020-03-13 11:00:13 [ERROR] Connection cannot established with given information, please check the server availability, or your parameters given
 2020-03-13 11:00:54 [DEBUG] mysqlnd_azure.c: mysqlnd_azure::connect()
 2020-03-13 11:00:54 [DEBUG] mysqlnd_azure.enableRedirect: PREFERRD
 2020-03-13 11:00:54 [INFO ] SSL not enabled, and mysqlnd_zaure.enableRedirect if PREFERRED, connection will go through gateway.
 2020-03-13 11:00:54 [DEBUG] mysqlnd_azure.c: mysqlnd_azure::connect()
 2020-03-13 11:00:54 [INFO ] No cache found
 2020-03-13 11:00:54 [DBEUG] mysqlnd_azure.c: mysqlnd_azure_data::connect()
 2020-03-13 11:00:54 [DEBUG] Connection Information: host=127.0.0.1 user=santo db=test port=3306 flags=131072 persistent=1 state=0
 2020-03-13 11:00:54 [ERROR] Connection cannot established with given information, please check the server availability, or your parameters given
 2020-03-13 11:00:54 [DEBUG] mysqlnd_azure.c: mysqlnd_azure::connect()
 2020-03-13 11:00:54 [INFO ] No cache found
 2020-03-13 11:00:54 [DBEUG] mysqlnd_azure.c: mysqlnd_azure_data::connect()
 2020-03-13 11:00:54 [DEBUG] Connection Information: host=santo.mysql.database.azure.com user=test@santo db= port=3306 flags=131072 persistent=1 state=0
 2020-03-13 11:00:54 [DEBUG] Classical connection OK, try to get REDIRECTION information
 2020-03-13 11:00:54 [DEBUG] mysqlnd_azure.c: get_redirect_info()
 2020-03-13 11:00:54 [DEBUG] Successfully get redirection information, try to connect with redirection connection
 2020-03-13 11:00:54 [DEBUG] mysqlnd_azure.c: set_redirect_client_options()
 2020-03-13 11:00:55 [DEBUG] Redirect conntion established.
 2020-03-13 11:00:55 [DEBUG] Prepare the context of new connection
 2020-03-13 11:00:55 [DEBUG] mysqlnd_azure.c: mysqlnd_azure::connect()
 2020-03-13 11:00:55 [DEBUG] mysqlnd_azure.enableRedirect: PREFERRD
 2020-03-13 11:00:55 [INFO ] SSL not enabled, and mysqlnd_zaure.enableRedirect if PREFERRED, connection will go through gateway.
```