### PR TITLE
fix crash due to wrong alloc pair

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -49,6 +49,7 @@
    <file md5sum="a678a17b08f337292c0471b26be405f5" name="tests/mysqli_azure_redirection_off.phpt" role="test" />
    <file md5sum="a678a17b08f337292c0471b26be405f5" name="tests/mysqli_azure_redirection_preferred.phpt" role="test" />
    <file md5sum="a678a17b08f337292c0471b26be405f5" name="tests/mysqli_azure_option_test.phpt" role="test" />   
+   <file md5sum="a678a17b08f337292c0471b26be405f5" name="tests/mysqli_azure_option_test_collect_memory_statistics.phpt" role="test" />
    <file md5sum="271878ad9afcd0f4304529ff9522e034" name="tests/connect.inc" role="test" />
    <file md5sum="d621e9a3ad808225480ee11b361338ad" name="tests/skipif.inc" role="test" />
    <file md5sum="841204de228db4ea0150bf7289956163" name="tests/skipif_mysqli.inc" role="test" />

--- a/redirect_cache.c
+++ b/redirect_cache.c
@@ -70,7 +70,7 @@ enum_func_status mysqlnd_azure_add_redirect_cache(const char* user, const char* 
         return FAIL;
     }
 
-    MYSQLND_AZURE_REDIRECT_INFO* redirect_info = pemalloc(sizeof(MYSQLND_AZURE_REDIRECT_INFO), 1);
+    MYSQLND_AZURE_REDIRECT_INFO* redirect_info = mnd_pemalloc(sizeof(MYSQLND_AZURE_REDIRECT_INFO), 1);
     if(redirect_info == NULL) {
         return FAIL;
     }

--- a/tests/connect.inc
+++ b/tests/connect.inc
@@ -14,7 +14,7 @@
     $passwd    = getenv("MYSQL_TEST_PASSWD")   ? getenv("MYSQL_TEST_PASSWD") : "";
     $db        = getenv("MYSQL_TEST_DB")       ? getenv("MYSQL_TEST_DB") : NULL;
     $engine    = getenv("MYSQL_TEST_ENGINE")   ? getenv("MYSQL_TEST_ENGINE") : "InnoDB";
-    $pdo_dsn        = getenv("PDO_MYSQL_TEST_DSN")   ? getenv("PDO_MYSQL_TEST_DSN") : "mysql:host=".$host.";dbname=".$db;
+    $pdo_dsn        = getenv("PDO_MYSQL_TEST_DSN")   ? getenv("PDO_MYSQL_TEST_DSN") : "mysql:host=localhost;dbname=";
     $ssl_cert_file  = getenv("MYSQL_SSL_CERT_FILE")   ? getenv("MYSQL_SSL_CERT_FILE") : NULL;
 
     $IS_MYSQLND = stristr(mysqli_get_client_info(), "mysqlnd");

--- a/tests/mysqli_azure_option_test_collect_memory_statistics.phpt
+++ b/tests/mysqli_azure_option_test_collect_memory_statistics.phpt
@@ -1,0 +1,136 @@
+--TEST--
+Azure redirection option test for mysqlnd_azure.enableRedirect
+--INI--
+mysqlnd.collect_statistics="1"
+mysqlnd.collect_memory_statistics="1"
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+?>
+--FILE--
+<?php
+require_once("connect.inc");
+
+function ini_set_test($value) {
+    global $host, $user, $passwd, $db, $port;
+
+    ini_set("mysqlnd_azure.enableRedirect", $value);
+    echo ini_get("mysqlnd_azure.enableRedirect"), "\n";
+    $link = mysqli_init();
+    $ret = @mysqli_real_connect($link, $host, $user, $passwd, $db, $port, NULL, NULL);
+    if(!$ret)
+        echo error_get_last()["message"], "\n";
+    
+    if($ret) {
+        if(substr($link->host_info, 0, strlen($host)) == $host)
+            echo "equal\n";
+        else
+            echo "not equal\n";
+        $link->close();
+    }
+    
+    $link = mysqli_init();
+    $ret = @mysqli_real_connect($link, $host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
+    $last_message = "";
+    if($ret)
+        $last_message =  $link->info;
+
+    //Server supports redirection
+    if(strlen($last_message) > 27 && strcmp(substr($last_message, 0, strlen("Location:")), "Location:")==0) {
+        $config = ini_get("mysqlnd_azure.enableRedirect");
+        if(substr($link->host_info, 0, strlen($host)) == $host && (strcasecmp($config, "preferred")==0 || strcasecmp($config, "2")==0))
+            echo "FAIL\n";
+        else
+            echo "PASS\n";
+    } 
+    else if($ret && is_object($link)) {
+        if(substr($link->host_info, 0, strlen($host)) == $host)
+            echo "PASS\n";
+        else
+            echo "FAIL\n";
+    }
+    else if(!$ret) { //Server does not support redirection and redirect on
+        $lastError = error_get_last()["message"];
+        if (strpos($lastError, "Connection aborted because redirection is not enabled on the MySQL server or the network package doesn't meet meet redirection protocol.") !== false)
+            echo "PASS\n";
+        else
+            echo "FAIL\n";
+    }
+    if($ret) $link->close();
+}
+
+ini_set_test("on");
+ini_set_test("On");
+ini_set_test("yes");
+ini_set_test("Yes");
+ini_set_test("true");
+ini_set_test("True");
+ini_set_test("1");
+ini_set_test(1);
+
+ini_set_test("preferred");
+ini_set_test("Preferred");
+ini_set_test("2");
+ini_set_test(2);
+
+ini_set_test("off");
+ini_set_test("Off");
+ini_set_test("0");
+ini_set_test(0);
+ini_set_test("otherValue");
+
+echo "Done\n";
+?>
+--EXPECTF--
+on
+mysqli_real_connect(): (HY000/2054): mysqlnd_azure.enableRedirect is on, but SSL option is not set in connection string. Redirection is only possible with SSL.
+PASS
+On
+mysqli_real_connect(): (HY000/2054): mysqlnd_azure.enableRedirect is on, but SSL option is not set in connection string. Redirection is only possible with SSL.
+PASS
+yes
+mysqli_real_connect(): (HY000/2054): mysqlnd_azure.enableRedirect is on, but SSL option is not set in connection string. Redirection is only possible with SSL.
+PASS
+Yes
+mysqli_real_connect(): (HY000/2054): mysqlnd_azure.enableRedirect is on, but SSL option is not set in connection string. Redirection is only possible with SSL.
+PASS
+true
+mysqli_real_connect(): (HY000/2054): mysqlnd_azure.enableRedirect is on, but SSL option is not set in connection string. Redirection is only possible with SSL.
+PASS
+True
+mysqli_real_connect(): (HY000/2054): mysqlnd_azure.enableRedirect is on, but SSL option is not set in connection string. Redirection is only possible with SSL.
+PASS
+1
+mysqli_real_connect(): (HY000/2054): mysqlnd_azure.enableRedirect is on, but SSL option is not set in connection string. Redirection is only possible with SSL.
+PASS
+1
+mysqli_real_connect(): (HY000/2054): mysqlnd_azure.enableRedirect is on, but SSL option is not set in connection string. Redirection is only possible with SSL.
+PASS
+preferred
+equal
+PASS
+Preferred
+equal
+PASS
+2
+equal
+PASS
+2
+equal
+PASS
+off
+equal
+PASS
+Off
+equal
+PASS
+0
+equal
+PASS
+0
+equal
+PASS
+otherValue
+equal
+PASS
+Done


### PR DESCRIPTION
when mysqlnd.collect_memory_statistics=1, it will cause crash if redirect cache is used. It is due to wrong use of alloc pair. Should always use mnd_ prefix for memory manipulation if want to take use of the mysqlnd.collect_memory_statistics usage.