### PR TITLE
Add {"_extension_version": MYSQLND_AZURE_VERSION} to connection attr

### DIFF
--- a/mysqlnd_azure.c
+++ b/mysqlnd_azure.c
@@ -618,6 +618,7 @@ MYSQLND_METHOD(mysqlnd_azure, connect)(MYSQLND * conn_handle,
 
     if (PASS == (*pconn)->m->local_tx_start(*pconn, this_func)) {
         mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_client_name", "mysqlnd");
+        mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_extension_version", MYSQLND_AZURE_VERSION);
         if (hostname.l > 0) {
             mysqlnd_options4(conn_handle, MYSQL_OPT_CONNECT_ATTR_ADD, "_server_host", hostname.s);
         }

--- a/mysqlnd_azure.h
+++ b/mysqlnd_azure.h
@@ -26,6 +26,8 @@
 #include "ext/mysqlnd/mysqlnd.h"
 #include "ext/mysqlnd/mysqlnd_debug.h"
 
+#define MYSQLND_AZURE_VERSION "mysqlnd_azure-1.1.1"
+
 /*struct to store redirection chache info in hash table*/
 typedef struct st_mysqlnd_azure_redirect_info {
     char* redirect_user;

--- a/package.xml
+++ b/package.xml
@@ -92,7 +92,8 @@
      <date>2020-05-13</date>
      <license uri="http://www.php.net/license">PHP License</license>
      <notes>
-- 1. New connection attribute "_extension_version", indicate the mysqlnd_azure extension build version
+- 1. New connection attribute "_extension_version", indicate the mysqlnd_azure extension build version.
+- 2. Fix memory collect mnd_ prefix alloc crash and add a test case for enable mysqlnd.collect_memory_statistics.
      </notes>
     </release>
     <release>

--- a/package.xml
+++ b/package.xml
@@ -19,8 +19,8 @@
  <date>2020-02-14</date>
  <time>16:00:13</time>
  <version>
-  <release>1.1.0</release>
-  <api>1.1.0</api>
+  <release>1.1.1</release>
+  <api>1.1.1</api>
  </version>
  <stability>
   <release>stable</release>
@@ -80,6 +80,21 @@
  <providesextension>mysqlnd_azure</providesextension>
  <extsrcrelease />
  <changelog>
+    <release>
+     <version>
+     <release>1.1.1</release>
+     <api>1.1.1</api>
+     </version>
+     <stability>
+      <release>beta</release>
+      <api>beta</api>
+     </stability>
+     <date>2020-05-13</date>
+     <license uri="http://www.php.net/license">PHP License</license>
+     <notes>
+- 1. New connection attribute "_extension_version", indicate the mysqlnd_azure extension build version
+     </notes>
+    </release>
     <release>
      <version>
      <release>1.1.0</release>

--- a/package.xml
+++ b/package.xml
@@ -28,13 +28,8 @@
  </stability>
  <license uri="http://www.php.net/license">PHP License</license>
  <notes>
-- 1. Rename option mysqlnd_azure.enabled to mysqlnd_azure.enableRedirect.
-- 2. Add a new option choice "preferred".
-- 3. When enableRedirect is "on", ssl is off, no connection will be made, return error "mysqlnd_azure.enableRedirect is on, but SSL option is not set in connection string. Redirection is only possible with SSL."
-- 4. When enableRedirect is "on", but on server side redirection is not available, abort the first connection and return error "Connection aborted because redirection is not enabled on the MySQL server or the network package doesn't meet meet redirection protocol."
-- 5. When enableRedirect is "on" and server supports redirection, but the redirected connection failed for any reason, also abort the first proxy connection. Return the error of the redirected connection.
-- 6. When enableRedirect is "preferred", it will use redirection if possible. 
-     If connection does not use SSL, or server does not support redirection, or redirected connection fails to connect for any non-fatal reason while the proxy connection is still a valid one, it will fallback to the first proxy connection.
+- 1. New connection attribute "_extension_version", indicate the mysqlnd_azure extension build version.
+- 2. Fix memory collect mnd_ prefix alloc crash and add a test case for enable mysqlnd.collect_memory_statistics.
  </notes>
  <contents>
   <dir name="/">

--- a/package.xml
+++ b/package.xml
@@ -86,8 +86,8 @@
      <api>1.1.1</api>
      </version>
      <stability>
-      <release>beta</release>
-      <api>beta</api>
+      <release>stable</release>
+      <api>stable</api>
      </stability>
      <date>2020-05-13</date>
      <license uri="http://www.php.net/license">PHP License</license>


### PR DESCRIPTION
Add a connection attribute "_extension_version" : "mysqlnd_azure-x.x.x", e.x. "_extension_version": "mysqlnd_azure-1.1.1".

`mysqlnd_azure.h: MYSQLND_AZURE_VERSION` variable should be changed if you want to make a new version number.

### How to get this variable:
`select * from performance_schema.session_account_connect_attrs;`
can show what attrs set for current session.