### PR TITLE
Fix problem that ssl ca and cipher property lost when cache failed to connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Required PHP min version: PHP7.2.15+, PHP7.3.2+, PHP7.4.0+.
 
 Valid version:
 The latest version is **1.1.1**. Please check [package.xml](/package.xml) for changelog details. Following are some special notice for certain versions:
+
 - 1.1.1  Enable runtime log check support. Fix crash problem when mysqlnd.collect_memory_statistics=1.
 - 1.1.0  Rename option mysqlnd_azure.enabled to mysqlnd_azure.enableRedirect, and add a new option value "preferred". When enableRedirect is "on", it will enforce redirection. Please check [package.xml](/package.xml) for changelog details.
 - 1.0.2  Limitation: crash when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false

--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ Extension name: **mysqlnd_azure**
 Required PHP min version: PHP7.2.15+, PHP7.3.2+, PHP7.4.0+.
 
 Valid version:
-The latest version is **1.1.2**. Please check [package.xml](/package.xml) for changelog details. Following are some special notice for certain versions:
-- 1.1.2  Fix for ssl_ca property lost when cache failed to connect
+The latest version is **1.1.1**. Please check [package.xml](/package.xml) for changelog details. Following are some special notice for certain versions:
 - 1.1.1  Enable runtime log check support. Fix crash problem when mysqlnd.collect_memory_statistics=1.
 - 1.1.0  Rename option mysqlnd_azure.enabled to mysqlnd_azure.enableRedirect, and add a new option value "preferred". When enableRedirect is "on", it will enforce redirection. Please check [package.xml](/package.xml) for changelog details.
 - 1.0.2  Limitation: crash when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Extension name: **mysqlnd_azure**
 Required PHP min version: PHP7.2.15+, PHP7.3.2+, PHP7.4.0+.
 
 Valid version:
-The latest version is **1.1.1**. Please check [package.xml](/package.xml) for changelog details. Following are some special notice for certain versions:
-
+The latest version is **1.1.2**. Please check [package.xml](/package.xml) for changelog details. Following are some special notice for certain versions:
+- 1.1.2  Fix for ssl_ca property lost when cache failed to connect
 - 1.1.1  Enable runtime log check support. Fix crash problem when mysqlnd.collect_memory_statistics=1.
 - 1.1.0  Rename option mysqlnd_azure.enabled to mysqlnd_azure.enableRedirect, and add a new option value "preferred". When enableRedirect is "on", it will enforce redirection. Please check [package.xml](/package.xml) for changelog details.
 - 1.0.2  Limitation: crash when working with PDO interface with flag PDO::ATTR_PERSISTENT=>false

--- a/package.xml
+++ b/package.xml
@@ -16,15 +16,15 @@
   <email>Qianqian.Bu@microsoft.com</email>
   <active>yes</active>
  </lead>
- <date>2020-09-10</date>
+ <date>2020-12-10</date>
  <time>16:00:13</time>
  <version>
   <release>1.1.2</release>
   <api>1.1.2</api>
  </version>
  <stability>
-  <release>stable</release>
-  <api>stable</api>
+  <release>PlaceHolder_ToRelease</release>
+  <api>PlaceHolder_ToRelease</api>
  </stability>
  <license uri="http://www.php.net/license">PHP License</license>
  <notes>
@@ -85,10 +85,10 @@
      <api>1.1.2</api>
      </version>
      <stability>
-      <release>stable</release>
-      <api>stable</api>
+      <release>PlaceHolder_ToRelease</release>
+      <api>PlaceHolder_ToRelease</api>
      </stability>
-     <date>2020-09-10</date>
+     <date>2020-12-10</date>
      <license uri="http://www.php.net/license">PHP License</license>
      <notes>
 - 1. Fix ssl_ca property lost problem when cache failed to connect

--- a/package.xml
+++ b/package.xml
@@ -16,11 +16,11 @@
   <email>Qianqian.Bu@microsoft.com</email>
   <active>yes</active>
  </lead>
- <date>2020-08-06</date>
+ <date>2020-09-10</date>
  <time>16:00:13</time>
  <version>
-  <release>1.1.1</release>
-  <api>1.1.1</api>
+  <release>1.1.2</release>
+  <api>1.1.2</api>
  </version>
  <stability>
   <release>stable</release>
@@ -28,11 +28,7 @@
  </stability>
  <license uri="http://www.php.net/license">PHP License</license>
  <notes>
-- 1. New connection attribute "_extension_version", indicate the mysqlnd_azure extension build version.
-- 2. Fix memory collect mnd_ prefix alloc crash and add a test case for enable mysqlnd.collect_memory_statistics.
-- 3. Add support for two redirection info format.
-- 4. Add support to enable runtime log, check myslqnd_azure_log.md
-- 5. Add doc for general troubleshooting.
+- 1. Fix ssl_ca property lost problem when cache failed to connect
  </notes>
  <contents>
   <dir name="/">
@@ -49,6 +45,7 @@
    <file md5sum="a678a17b08f337292c0471b26be405f5" name="tests/mysqli_azure_redirection_preferred.phpt" role="test" />
    <file md5sum="a678a17b08f337292c0471b26be405f5" name="tests/mysqli_azure_option_test.phpt" role="test" />   
    <file md5sum="a678a17b08f337292c0471b26be405f5" name="tests/mysqli_azure_option_test_collect_memory_statistics.phpt" role="test" />
+   <file md5sum="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" name="tests/mysqli_azure_cache_invalid.phpt" role="test" />
    <file md5sum="271878ad9afcd0f4304529ff9522e034" name="tests/connect.inc" role="test" />
    <file md5sum="d621e9a3ad808225480ee11b361338ad" name="tests/skipif.inc" role="test" />
    <file md5sum="841204de228db4ea0150bf7289956163" name="tests/skipif_mysqli.inc" role="test" />
@@ -82,6 +79,21 @@
  <providesextension>mysqlnd_azure</providesextension>
  <extsrcrelease />
  <changelog>
+   <release>
+     <version>
+     <release>1.1.2</release>
+     <api>1.1.2</api>
+     </version>
+     <stability>
+      <release>stable</release>
+      <api>stable</api>
+     </stability>
+     <date>2020-09-10</date>
+     <license uri="http://www.php.net/license">PHP License</license>
+     <notes>
+- 1. Fix ssl_ca property lost problem when cache failed to connect
+     </notes>
+    </release>
     <release>
      <version>
      <release>1.1.1</release>

--- a/php_mysqlnd_azure.h
+++ b/php_mysqlnd_azure.h
@@ -29,7 +29,7 @@ extern zend_module_entry mysqlnd_azure_module_entry;
 #define phpext_mysqlnd_azure_ptr &mysqlnd_azure_module_entry
 
 #define PHP_MYSQLND_AZURE_NAME      "mysqlnd_azure"
-#define PHP_MYSQLND_AZURE_VERSION   "1.1.1"
+#define PHP_MYSQLND_AZURE_VERSION   "1.1.2"
 
 #define STRING_EQUALS(z_str,str) (ZSTR_LEN((z_str)) == strlen((str)) && strcasecmp((str), ZSTR_VAL((z_str))) == 0)
 

--- a/tests/mysqli_azure_cache_invalid.phpt
+++ b/tests/mysqli_azure_cache_invalid.phpt
@@ -1,0 +1,63 @@
+--TEST--
+Azure redirection test for servers whether ssl_ca will be kept if use cache failed
+--INI--
+mysqlnd_azure.enableRedirect="on"
+--SKIPIF--
+<?php
+require_once('skipif.inc');
+?>
+--FILE--
+<?php
+require_once("connect.inc");
+
+//Step 1: check option setting
+$tmp = ini_get("mysqlnd_azure.enableRedirect");
+echo $tmp."\n";
+if (strcmp($tmp, "on")!=0)
+{
+	printf("[001] mysqlnd_azure.enableRedirect not set to on, got '%s'\n", $tmp);
+    die();
+}
+
+//Step 1: first connection use SSL
+$link = mysqli_init();
+$ret = @mysqli_real_connect($link, $host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
+if (!$ret || !is_object($link))
+{
+	printf("[002] Cannot connect to the server using host=%s, user=%s, passwd=***, dbname=%s, port=%s, socket=%s\n  - [%d] %s with ssl\n",
+			$host, $user, $db, $port, $socket, mysqli_connect_errno(), mysqli_connect_error());
+	die();
+}
+echo $link->host_info."\n";
+$link->close();
+
+
+//Step 2: Second connection use SSL with invalid ca option. Should use cache and failed.
+$link = mysqli_init();
+mysqli_ssl_set($link, null,null,"A_Invalid_ca_ath.pem",null, null);
+$ret = mysqli_real_connect($link, $host, $user, $passwd, $db, $port, NULL, MYSQLI_CLIENT_SSL);
+if ($ret)
+{
+	printf("[003] Connection with invalid ca info should failed\n");
+}
+
+echo "Done\n";
+?>
+--EXPECTF--
+on
+%s
+
+Warning: failed loading cafile stream: `A_Invalid_ca_ath.pem' in %s
+
+Warning: mysqli_real_connect(): Cannot connect to MySQL by using SSL in %s
+
+Warning: mysqli_real_connect(): [2002]  (trying to connect via (null)) in %s
+
+Warning: failed loading cafile stream: `A_Invalid_ca_ath.pem' in %s
+
+Warning: mysqli_real_connect(): Cannot connect to MySQL by using SSL in %s
+
+Warning: mysqli_real_connect(): [2002]  (trying to connect via (null)) in %s
+
+Warning: mysqli_real_connect(): (HY000/2002):  in %s
+Done


### PR DESCRIPTION
Fix problem that ssl ca and cipher property lost when cache failed to connect.
Use a new object to establish the new cached connection instead, if success, use it to replace original conn_data, otherwise simply free it.